### PR TITLE
Disable glow

### DIFF
--- a/Game/Hymn.json
+++ b/Game/Hymn.json
@@ -18,7 +18,7 @@
 		},
 		"fogDensity" : 0.0010000000474974513,
 		"fxaa" : true,
-		"glow" : true,
+		"glow" : false,
 		"glowBlurAmount" : 1
 	},
 	"input" : 


### PR DESCRIPTION
We're currently not using any emissive materials. Having glow on leads to unnecessary performance loss.