### PR TITLE
Update entity transforms of physics components.

### DIFF
--- a/src/Engine/Hymn.cpp
+++ b/src/Engine/Hymn.cpp
@@ -185,6 +185,10 @@ void ActiveHymn::Update(float deltaTime) {
     { PROFILE("Update debug drawing");
         Managers().debugDrawingManager->Update(deltaTime);
     }
+
+    { PROFILE("Synchronize transforms");
+        Managers().physicsManager->UpdateEntityTransforms(world);
+    }
     
     { PROFILE("Clear killed entities/components");
         world.ClearKilled();

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -1,8 +1,10 @@
 #include "PhysicsManager.hpp"
 
 #include <btBulletDynamicsCommon.h>
+#include <glm/gtx/quaternion.hpp>
 #include "../Component/Physics.hpp"
 #include "../Entity/Entity.hpp"
+#include "../Physics/GlmConversion.hpp"
 #include "../Physics/ITrigger.hpp"
 #include "../Physics/RigidBody.hpp"
 #include "../Physics/Shape.hpp"
@@ -84,6 +86,20 @@ void PhysicsManager::Update(World &world, float deltaTime) {
 
     for (auto trigger : triggers) {
         trigger->Process(*dynamicsWorld);
+    }
+}
+
+void PhysicsManager::UpdateEntityTransforms(World& world) {
+    std::vector<Component::Physics*> physicsObjects = this->GetComponents<Component::Physics>(&world);
+    for (Component::Physics* physicsComp : physicsObjects) {
+        if (physicsComp->IsKilled() || !physicsComp->entity->enabled)
+            continue;
+
+        Entity* entity = physicsComp->entity;
+
+        auto trans = physicsComp->GetRigidBody().GetRigidBody()->getWorldTransform();
+        entity->position = Physics::btToGlm(trans.getOrigin());
+        entity->rotation = glm::eulerAngles(Physics::btToGlm(trans.getRotation()));
     }
 }
 

--- a/src/Engine/Manager/PhysicsManager.hpp
+++ b/src/Engine/Manager/PhysicsManager.hpp
@@ -35,6 +35,13 @@ class PhysicsManager : public SuperManager {
          */
         void Update(World& world, float deltaTime);
 
+        /// Update transforms of entities according to positions of physics
+        /// components.
+        /**
+         * @param world The world in which components reside? Wat?
+         */
+        void UpdateEntityTransforms(World& world);
+
         void OnTriggerEnter(Component::Physics* triggerBody, Component::Physics* object, std::function<void()> callback);
 
     private:

--- a/src/Engine/Physics/GlmConversion.cpp
+++ b/src/Engine/Physics/GlmConversion.cpp
@@ -10,4 +10,8 @@ namespace Physics {
         return glm::vec3(vec.getX(), vec.getY(), vec.getZ());
     }
 
+    glm::quat btToGlm(btQuaternion const& quat) {
+        return glm::quat(quat.getX(), quat.getY(), quat.getZ(), quat.getW());
+    }
+
 }

--- a/src/Engine/Physics/GlmConversion.hpp
+++ b/src/Engine/Physics/GlmConversion.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <glm/glm.hpp>
+#include <glm/gtx/quaternion.hpp>
 #include <LinearMath/btVector3.h>
+#include <LinearMath/btQuaternion.h>
 
 namespace Physics {
 
@@ -18,5 +20,12 @@ namespace Physics {
      * @return Converted vector.
      */
     glm::vec3 btToGlm(btVector3 const& vec);
+
+    /// Convert Bullet quaternion to GLM quaternion.
+    /**
+     * @param quat Quaternion to convert.
+     * @return Converted quaternion.
+     */
+    glm::quat btToGlm(btQuaternion const& quat);
 
 }


### PR DESCRIPTION
For physics components, update entity position to that of the rigid body. Note that this essentially destroys the script because we always force the position to a fixed one.