### PR TITLE
Physics positioning

### DIFF
--- a/Game/Scenes/TestScene.json
+++ b/Game/Scenes/TestScene.json
@@ -81,7 +81,7 @@
 				{
 					"sphere" : 
 					{
-						"radius" : 13.369999885559082
+						"radius" : 1.0
 					}
 				},
 				"velocity" : 
@@ -346,9 +346,9 @@
 								{
 									"x" : 0.0,
 									"y" : 0.0,
-									"z" : -1.0
+									"z" : 1.0
 								},
-								"planeCoeff" : 0.0
+								"planeCoeff" : 450.0
 							}
 						},
 						"velocity" : 

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -80,6 +80,11 @@ void PhysicsManager::Update(float deltaTime) {
         
         // Update rotation.
         entity->rotation += physicsComp->angularVelocity * 360.f * deltaTime;
+
+        physicsComp->GetRigidBody().Position(entity->position);
+        dynamicsWorld->removeRigidBody(physicsComp->GetRigidBody().GetRigidBody());
+        dynamicsWorld->addRigidBody(physicsComp->GetRigidBody().GetRigidBody());
+        physicsComp->GetRigidBody().GetRigidBody()->setGravity(btVector3(0, 0, 0));
     }
 
     dynamicsWorld->stepSimulation(deltaTime, 10);

--- a/src/Engine/Physics/RigidBody.cpp
+++ b/src/Engine/Physics/RigidBody.cpp
@@ -15,6 +15,7 @@ namespace Physics {
         btRigidBody::btRigidBodyConstructionInfo constructionInfo(mass, motionState, shape->GetShape(), btVector3(0, 0, 0));
         rigidBody = new btRigidBody(constructionInfo);
         rigidBody->setUserPointer(this);
+        rigidBody->setCollisionFlags(rigidBody->getCollisionFlags() | btCollisionObject::CF_NO_CONTACT_RESPONSE);
     }
 
     RigidBody::~RigidBody() {


### PR DESCRIPTION
Sets position of physics component before simulation (outside the physics manager we update entities after simulation). A temporary fix to work around that we use rigid bodies even though they are not really dynamic is that we manually disable gravity to not make the cart fall down. I also fixed some errors in the plane positioning and set the cart collider to a more reasonable size (sphere with 1m radius).