### PR TITLE
Entity static check

### DIFF
--- a/Game/Scenes/TestScene.json
+++ b/Game/Scenes/TestScene.json
@@ -33,6 +33,7 @@
 				"z" : 1.0
 			},
 			"scene" : false,
+			"static" : false,
 			"uid" : 1
 		},
 		{
@@ -130,6 +131,7 @@
 						"z" : 1.0
 					},
 					"scene" : false,
+					"static" : false,
 					"uid" : 4
 				},
 				{
@@ -166,6 +168,7 @@
 						"z" : 1.0
 					},
 					"scene" : false,
+					"static" : false,
 					"uid" : 5
 				}
 			],
@@ -189,6 +192,7 @@
 				"z" : 1.0
 			},
 			"scene" : false,
+			"static" : false,
 			"uid" : 2
 		},
 		{
@@ -231,6 +235,7 @@
 						"z" : 0.5
 					},
 					"scene" : false,
+					"static" : false,
 					"uid" : 1506428286
 				},
 				{
@@ -270,6 +275,7 @@
 						"z" : 1.0
 					},
 					"scene" : false,
+					"static" : false,
 					"uid" : 1506428288
 				},
 				{
@@ -345,6 +351,7 @@
 						"z" : 1.0
 					},
 					"scene" : false,
+					"static" : false,
 					"uid" : 1506510737
 				}
 			],
@@ -368,6 +375,7 @@
 				"z" : 1.0
 			},
 			"scene" : false,
+			"static" : false,
 			"uid" : 1506431025
 		},
 		{
@@ -403,6 +411,7 @@
 				"z" : 1.0
 			},
 			"scene" : false,
+			"static" : false,
 			"uid" : 3
 		}
 	],
@@ -426,5 +435,6 @@
 		"z" : 1.0
 	},
 	"scene" : false,
+	"static" : false,
 	"uid" : 0
 }

--- a/src/Editor/GUI/Editors/EntityEditor.cpp
+++ b/src/Editor/GUI/Editors/EntityEditor.cpp
@@ -76,6 +76,7 @@ void EntityEditor::Show() {
         ImGui::DraggableVec3("Rotation", entity->rotation);
         ImGui::DraggableVec3("Scale", entity->scale);
         ImGui::Text("Unique Identifier: %u", entity->GetUniqueIdentifier());
+        ImGui::Checkbox("Is entity static", &entity->isStatic);
         ImGui::Unindent();
         if (!entity->IsScene()) {
             if (ImGui::Button("Add component"))

--- a/src/Editor/GUI/ResourceView.cpp
+++ b/src/Editor/GUI/ResourceView.cpp
@@ -46,7 +46,7 @@ void ResourceView::Show() {
         for (std::size_t i = 0; i < Resources().scenes.size(); ++i) {
             if (ImGui::Selectable(Resources().scenes[i].c_str())) {
                 // Sets to dont save when opening first scene.
-                if (Resources().activeScene == -1) {
+                if (sceneIndex == -1) {
                     changeScene = true;
                     sceneIndex = i;
                     savePromptWindow.SetVisible(false);

--- a/src/Engine/Entity/Entity.cpp
+++ b/src/Engine/Entity/Entity.cpp
@@ -141,7 +141,8 @@ Json::Value Entity::Save() const {
     entity["rotation"] = Json::SaveVec3(rotation);
     entity["scene"] = scene;
     entity["uid"] = uniqueIdentifier;
-    
+    entity["static"] = isStatic;
+
     if (scene) {
         entity["sceneName"] = sceneName;
     } else {
@@ -211,6 +212,7 @@ void Entity::Load(const Json::Value& node) {
     scale = Json::LoadVec3(node["scale"]);
     rotation = Json::LoadVec3(node["rotation"]);
     uniqueIdentifier = node.get("uid", 0).asUInt();
+    isStatic = node["static"].asBool();
     
 }
 

--- a/src/Engine/Entity/Entity.hpp
+++ b/src/Engine/Entity/Entity.hpp
@@ -184,6 +184,9 @@ class Entity {
 
         /// Whether the entity is active.
         bool enabled = true;
+
+        /// Whether the entity is static.
+        bool isStatic = false;
         
     private:
         template<typename T> void Save(Json::Value& node, const std::string& name) const;


### PR DESCRIPTION
Added a static parameter to entities which can be set to false and true in the editor (False is default).
Also changed the check in ResourceView so that the first scene can be opened when first starting up the hymn. This was such a small change that I added it to this pull request rather than making a whole new branch just for it.