### PR TITLE
Check for changes before save prompt

### DIFF
--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -19,6 +19,7 @@
 
 #include <imgui.h>
 #include <GLFW/glfw3.h>
+#include <fstream>
 
 Editor::Editor() {
     // Create Hymns directory.
@@ -80,33 +81,41 @@ Editor::~Editor() {
 
 void Editor::Show(float deltaTime) {
     if (close) {
-        // Ask the user whether they wish to save.
-        if (Hymn().GetPath() != "") {
-            savePromtWindow.SetVisible(true);
-            savePromtWindow.Show();
 
-            switch (savePromtWindow.GetDecision()) {
-            case 0:
-                Save();
-                savePromptAnswered = true;
-                break;
-
-            case 1:
-                savePromptAnswered = true;
-                break;
-
-            case 2:
-                savePromptAnswered = false;
-                close = false;
-                savePromtWindow.ResetDecision();
-                break;
-
-            default:
-                break;
-            }
+        if (!HasMadeChanges()) {
+            savePromptAnswered = true;
         }
         else {
-            savePromptAnswered = true;
+
+            // Ask the user whether they wish to save.
+            if (Hymn().GetPath() != "") {
+                savePromtWindow.SetVisible(true);
+                savePromtWindow.Show();
+
+                switch (savePromtWindow.GetDecision()) {
+                case 0:
+                    Save();
+                    savePromptAnswered = true;
+                    break;
+
+                case 1:
+                    savePromptAnswered = true;
+                    break;
+
+                case 2:
+                    savePromptAnswered = false;
+                    close = false;
+                    savePromtWindow.ResetDecision();
+                    break;
+
+                default:
+                    break;
+                }
+            }
+            else {
+                savePromptAnswered = true;
+            }
+
         }
     }
     else {
@@ -362,6 +371,76 @@ void Editor::Save() const {
     resourceView.SaveScene();
     Hymn().Save();
     Resources().Save();
+}
+
+bool Editor::HasMadeChanges() const {
+    
+    {
+        std::string* sceneFilename = new std::string();
+        Json::Value sceneJson = resourceView.GetSceneJson(sceneFilename);
+
+        // Load Json document from file.
+        Json::Value reference;
+        std::ifstream file(*sceneFilename);
+
+        if (!file.good())
+            return true;
+
+        file >> reference;
+        file.close();
+
+        std::string sceneJsonString = sceneJson.toStyledString();
+        std::string referenceString = reference.toStyledString();
+
+        int response = referenceString.compare(sceneJsonString);
+        if (response != 0)
+            return true;
+    }
+    {
+        std::string hymnFilename = Hymn().GetSavePath();
+        Json::Value hymnJson = Hymn().ToJson();
+
+        // Load Json document from file.
+        Json::Value reference;
+        std::ifstream file(hymnFilename);
+
+        if (!file.good())
+            return true;
+
+        file >> reference;
+        file.close();
+
+        std::string hymnJsonString = hymnJson.toStyledString();
+        std::string referenceString = reference.toStyledString();
+
+        int response = referenceString.compare(hymnJsonString);
+        if (response != 0)
+            return true;
+    }
+    {
+        std::string resourcesFilename = Resources().GetSavePath();
+        Json::Value resourcesJson = Resources().ToJson();
+
+        // Load Json document from file.
+        Json::Value reference;
+        std::ifstream file(resourcesFilename);
+
+        if (!file.good())
+            return true;
+
+        file >> reference;
+        file.close();
+
+        std::string resourcesJsonString = resourcesJson.toStyledString();
+        std::string referenceString = reference.toStyledString();
+
+        int response = referenceString.compare(resourcesJsonString);
+        if (response != 0)
+            return true;
+    }
+
+    return false;
+
 }
 
 bool Editor::ReadyToClose() const {

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -28,6 +28,12 @@ class Editor {
          */
         void Show(float deltaTime);
         
+        /// Show the editor.
+        /**
+         * @return Check if you have made any changes to the scene.
+         */
+        bool HasMadeChanges() const;
+
         /// Save the hymn being edited.
         void Save() const;
 

--- a/src/Editor/GUI/Editors/SceneEditor.cpp
+++ b/src/Editor/GUI/Editors/SceneEditor.cpp
@@ -95,6 +95,18 @@ void SceneEditor::Save() const {
         Hymn().world.Save(Hymn().GetPath() + FileSystem::DELIMITER + "Scenes" + FileSystem::DELIMITER + Resources().scenes[sceneIndex] + ".json");
 }
 
+Json::Value SceneEditor::GetSaveFileJson(std::string* filename) const {
+    if (sceneIndex < Resources().scenes.size()) {
+
+        *filename = Hymn().GetPath() + FileSystem::DELIMITER + "Scenes" + FileSystem::DELIMITER + Resources().scenes[sceneIndex] + ".json";
+        return Hymn().world.GetSaveJson();
+
+    }
+
+    return Json::Value();
+
+}
+
 void SceneEditor::ShowEntity(Entity* entity) {
     bool leaf = entity->IsScene() || entity->GetChildren().empty();
     bool opened = ImGui::TreeNodeEx(entity->name.c_str(), leaf ? ImGuiTreeNodeFlags_Leaf : 0);

--- a/src/Editor/GUI/Editors/SceneEditor.hpp
+++ b/src/Editor/GUI/Editors/SceneEditor.hpp
@@ -35,7 +35,13 @@ namespace GUI {
             
             /// Save currently open scene to file.
             void Save() const;
-            
+
+            /// Gets a Json file representing the save file.
+            /**
+             * @param filename This is where the filename will be stored.
+             */
+            Json::Value GetSaveFileJson(std::string* filename) const;
+
             /// Did we press on an entity this frame.
             bool entityPressed = false;
             

--- a/src/Editor/GUI/ResourceView.cpp
+++ b/src/Editor/GUI/ResourceView.cpp
@@ -83,44 +83,37 @@ void ResourceView::Show() {
 
             if (Hymn().GetPath() != "") {
 
-                savePromptWindow.SetVisible(true);
-                savePromptWindow.Show();
+                if (!HasMadeChanges()) {
 
-                switch (savePromptWindow.GetDecision())
-                {
-                case 0:
-                    sceneEditor.Save();
-                    sceneEditor.SetVisible(true);
-                    sceneEditor.SetScene(sceneIndex);
-                    Resources().activeScene = sceneIndex;
-                    sceneEditor.entityEditor.SetVisible(false);
-                    Hymn().world.Clear();
-                    Hymn().world.Load(Hymn().GetPath() + FileSystem::DELIMITER + "Scenes" + FileSystem::DELIMITER + Resources().scenes[sceneIndex] + ".json");
-                    changeScene = false;
-                    savePromptWindow.SetVisible(false);
-                    savePromptWindow.ResetDecision();
-                    break;
+                    SwitchScene(sceneIndex);
 
-                case 1:
-                    sceneEditor.SetVisible(true);
-                    sceneEditor.SetScene(sceneIndex);
-                    Resources().activeScene = sceneIndex;
-                    sceneEditor.entityEditor.SetVisible(false);
-                    Hymn().world.Clear();
-                    Hymn().world.Load(Hymn().GetPath() + FileSystem::DELIMITER + "Scenes" + FileSystem::DELIMITER + Resources().scenes[sceneIndex] + ".json");
-                    changeScene = false;
-                    savePromptWindow.SetVisible(false);
-                    savePromptWindow.ResetDecision();
-                    break;
+                }
+                else {
 
-                case 2:
-                    changeScene = false;
-                    savePromptWindow.ResetDecision();
-                    savePromptWindow.SetVisible(false);
-                    break;
+                    savePromptWindow.SetVisible(true);
+                    savePromptWindow.Show();
 
-                default:
-                    break;
+                    switch (savePromptWindow.GetDecision())
+                    {
+                    case 0:
+                        sceneEditor.Save();
+                        SwitchScene(sceneIndex);
+                        break;
+
+                    case 1:
+                        SwitchScene(sceneIndex);
+                        break;
+
+                    case 2:
+                        changeScene = false;
+                        savePromptWindow.ResetDecision();
+                        savePromptWindow.SetVisible(false);
+                        break;
+
+                    default:
+                        break;
+
+                    }
                 }
             }
         }
@@ -305,6 +298,32 @@ void ResourceView::Show() {
     ImGui::End();
 }
 
+bool ResourceView::HasMadeChanges() const{
+
+    std::string* sceneFilename = new std::string();
+    Json::Value sceneJson = sceneEditor.GetSaveFileJson(sceneFilename);
+
+    // Load Json document from file.
+    Json::Value reference;
+    std::ifstream file(*sceneFilename);
+
+    if (!file.good())
+        return true;
+
+    file >> reference;
+    file.close();
+
+    std::string hymnJsonString = sceneJson.toStyledString();
+    std::string referenceString = reference.toStyledString();
+
+    int response = referenceString.compare(hymnJsonString);
+    if (response != 0)
+        return true;
+
+    return false;
+
+}
+
 bool ResourceView::IsVisible() const {
     return visible;
 }
@@ -324,6 +343,24 @@ void ResourceView::HideEditors() {
 
 void ResourceView::SaveScene() const {
     sceneEditor.Save();
+}
+
+Json::Value ResourceView::GetSceneJson(std::string* filename) const {
+    return sceneEditor.GetSaveFileJson(filename);
+}
+
+void ResourceView::SwitchScene(int index) {
+
+    sceneEditor.SetVisible(true);
+    sceneEditor.SetScene(index);
+    Resources().activeScene = index;
+    sceneEditor.entityEditor.SetVisible(false);
+    Hymn().world.Clear();
+    Hymn().world.Load(Hymn().GetPath() + FileSystem::DELIMITER + "Scenes" + FileSystem::DELIMITER + Resources().scenes[index] + ".json");
+    changeScene = false;
+    savePromptWindow.SetVisible(false);
+    savePromptWindow.ResetDecision();
+
 }
 
 #undef max

--- a/src/Editor/GUI/ResourceView.hpp
+++ b/src/Editor/GUI/ResourceView.hpp
@@ -17,6 +17,12 @@ namespace GUI {
             /// Show the resource list.
             void Show();
             
+            /// Checks if any changes has been made to the current scene.
+            /**
+             * @return Has any changes been made.
+             */
+            bool HasMadeChanges() const;
+
             /// Get whether the resource list is visible.
             /**
              * @return Whether the resource list is visible.
@@ -38,6 +44,18 @@ namespace GUI {
             /// Save the currently active scene.
             void SaveScene() const;
             
+            /// Switches to a new scene
+            /**
+             * @param index The index of the scene we want to switch to.
+             */
+            void SwitchScene(int index);
+
+            /// Get a json representing the scene.
+            /**
+             * @param filename The json file representing the scene.
+             */
+            Json::Value GetSceneJson(std::string* filename) const;
+
             /// Reset which scene is open.
             void ResetScene();
 

--- a/src/Editor/Resources.cpp
+++ b/src/Editor/Resources.cpp
@@ -22,10 +22,18 @@ ResourceList& ResourceList::GetInstance() {
 }
 
 void ResourceList::Save() const {
+    // Save to file.
+    ofstream file(GetSavePath());
+    file << ToJson();
+    file.close();
+}
+
+Json::Value ResourceList::ToJson() const {
+
     Json::Value root;
-    
+
     root["activeScene"] = activeScene;
-    
+
     // Save textures.
     Json::Value texturesNode;
     for (TextureAsset* texture : textures) {
@@ -33,38 +41,36 @@ void ResourceList::Save() const {
         texture->Save();
     }
     root["textures"] = texturesNode;
-    
+
     // Save models.
     Json::Value modelsNode;
     for (Geometry::Model* model : models) {
         modelsNode.append(model->name);
     }
     root["models"] = modelsNode;
-    
+
     // Save sounds.
     Json::Value soundsNode;
     for (Audio::SoundBuffer* sound : sounds) {
         soundsNode.append(sound->name);
     }
     root["sounds"] = soundsNode;
-    
+
     // Save scenes.
     Json::Value scenesNode;
     for (const string& scene : scenes) {
         scenesNode.append(scene);
     }
     root["scenes"] = scenesNode;
-    
-    // Save to file.
-    ofstream file(Hymn().GetPath() + FileSystem::DELIMITER + "Resources.json");
-    file << root;
-    file.close();
+
+    return root;
+
 }
 
 void ResourceList::Load() {
     // Load Json document from file.
     Json::Value root;
-    ifstream file(Hymn().GetPath() + FileSystem::DELIMITER + "Resources.json");
+    ifstream file(GetSavePath());
     file >> root;
     file.close();
     
@@ -119,6 +125,12 @@ void ResourceList::Clear() {
     }
     sounds.clear();
     soundNumber = 0U;
+}
+
+std::string ResourceList::GetSavePath() const{
+
+    return Hymn().GetPath() + FileSystem::DELIMITER + "Resources.json";
+
 }
 
 ResourceList& Resources() {

--- a/src/Editor/Resources.hpp
+++ b/src/Editor/Resources.hpp
@@ -11,6 +11,9 @@ namespace Geometry {
 namespace Audio {
     class SoundBuffer;
 }
+namespace Json {
+    class Value;
+}
 
 /// A list of all the resources in a hymn.
 class ResourceList {
@@ -19,7 +22,13 @@ class ResourceList {
     public:
         /// Save all resources to file.
         void Save() const;
-        
+
+        /// Creates a Json file for the resources.
+        /**
+         * @return A json file representing the resources.
+         */
+        Json::Value ToJson() const;
+
         /// Load all resources from file.
         void Load();
         
@@ -49,6 +58,12 @@ class ResourceList {
     
         /// The id of the next sound to create.
         unsigned int soundNumber = 0U;
+
+        /// Gets the path where it's saved.
+        /**
+         * @return The full path.
+         */
+        std::string GetSavePath() const;
         
     private:
         static ResourceList& GetInstance();

--- a/src/Engine/Entity/World.cpp
+++ b/src/Engine/Entity/World.cpp
@@ -95,10 +95,14 @@ void World::SetParticleCount(unsigned int particleCount) {
 
 void World::Save(const std::string& filename) const {
     Json::Value rootNode = root->Save();
-    
+
     std::ofstream file(filename);
     file << rootNode;
     file.close();
+}
+
+Json::Value World::GetSaveJson() const {
+    return root->Save();
 }
 
 void World::Load(const std::string& filename) {

--- a/src/Engine/Entity/World.hpp
+++ b/src/Engine/Entity/World.hpp
@@ -9,6 +9,9 @@ class Entity;
 namespace Component {
     class SuperComponent;
 }
+namespace Json {
+    class Value;
+}
 
 /// The game world containing all entities.
 class World {
@@ -84,7 +87,13 @@ class World {
          * @param filename The name of the file.
          */
         void Save(const std::string& filename) const;
-        
+
+        /// Get a json file representing the root.
+        /**
+         * @return The json file representing the root.
+         */
+        Json::Value GetSaveJson() const;
+
         /// Load the world from file.
         /**
          * @param filename The name of the file.

--- a/src/Engine/Hymn.cpp
+++ b/src/Engine/Hymn.cpp
@@ -80,9 +80,15 @@ void ActiveHymn::SetPath(const string& path) {
     FileSystem::CreateDirectory((path + FileSystem::DELIMITER + "Textures").c_str());
 }
 
+std::string ActiveHymn::GetSavePath() const {
+
+    return path + FileSystem::DELIMITER + "Hymn.json";
+
+}
+
 void ActiveHymn::Save() const {
     // Save to file.
-    ofstream file(path + FileSystem::DELIMITER + "Hymn.json");
+    ofstream file(GetSavePath());
     file << ToJson();
     file.close();
 }
@@ -93,7 +99,7 @@ void ActiveHymn::Load(const string& path) {
     
     // Load Json document from file.
     Json::Value root;
-    ifstream file(path + FileSystem::DELIMITER + "Hymn.json");
+    ifstream file(GetSavePath());
     file >> root;
     file.close();
     

--- a/src/Engine/Hymn.hpp
+++ b/src/Engine/Hymn.hpp
@@ -27,7 +27,13 @@ class ActiveHymn {
          * @param path New path.
          */
         void SetPath(const std::string& path);
-        
+
+        /// Gets the path to the hymn file.
+        /**
+         * @return The full path.
+         */
+        std::string GetSavePath() const;
+
         /// Save the hymn.
         void Save() const;
         


### PR DESCRIPTION
We now check if the json files are different before asking the player to save. Brute force, but good enough.
fixes #358  