### PR TITLE
Don't early return in resource view

### DIFF
--- a/src/Editor/GUI/ResourceView.cpp
+++ b/src/Editor/GUI/ResourceView.cpp
@@ -202,8 +202,6 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             resourcePath = path;
             parentFolder = &folder;
             folderNameWindow.SetVisible(true);
-            ImGui::EndPopup();
-            return;
         }
         
         // Add scene.
@@ -212,8 +210,6 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             resource.type = ResourceList::Resource::SCENE;
             resource.scene = "Scene #" + std::to_string(Resources().sceneNumber++);
             folder.resources.push_back(resource);
-            ImGui::EndPopup();
-            return;
         }
         
         // Add model.
@@ -224,8 +220,6 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             resource.model->path = path + "/";
             resource.model->name = "Model #" + std::to_string(Resources().modelNumber++);
             folder.resources.push_back(resource);
-            ImGui::EndPopup();
-            return;
         }
         
         // Add texture.
@@ -235,8 +229,6 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             string name = path + "/Texture #" + std::to_string(Resources().textureNumber++);
             resource.texture = Managers().resourceManager->CreateTextureAsset(name, Managers().resourceManager->CreateTexture2D(DEFAULTALBEDO_PNG, DEFAULTALBEDO_PNG_LENGTH));
             folder.resources.push_back(resource);
-            ImGui::EndPopup();
-            return;
         }
         
         // Add script.
@@ -248,8 +240,6 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             resource.script->name = "Script #" + std::to_string(Hymn().scriptNumber++);
             Hymn().scripts.push_back(resource.script);
             folder.resources.push_back(resource);
-            ImGui::EndPopup();
-            return;
         }
         
         // Add sound.
@@ -260,8 +250,6 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             resource.sound->path = path + "/";
             resource.sound->name = "Sound #" + std::to_string(Resources().soundNumber++);
             folder.resources.push_back(resource);
-            ImGui::EndPopup();
-            return;
         }
         
         /// @todo Remove folder.

--- a/src/Editor/GUI/ResourceView.cpp
+++ b/src/Editor/GUI/ResourceView.cpp
@@ -202,6 +202,7 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             resourcePath = path;
             parentFolder = &folder;
             folderNameWindow.SetVisible(true);
+            ImGui::EndPopup();
             return;
         }
         
@@ -211,6 +212,7 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             resource.type = ResourceList::Resource::SCENE;
             resource.scene = "Scene #" + std::to_string(Resources().sceneNumber++);
             folder.resources.push_back(resource);
+            ImGui::EndPopup();
             return;
         }
         
@@ -222,6 +224,7 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             resource.model->path = path + "/";
             resource.model->name = "Model #" + std::to_string(Resources().modelNumber++);
             folder.resources.push_back(resource);
+            ImGui::EndPopup();
             return;
         }
         
@@ -232,6 +235,7 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             string name = path + "/Texture #" + std::to_string(Resources().textureNumber++);
             resource.texture = Managers().resourceManager->CreateTextureAsset(name, Managers().resourceManager->CreateTexture2D(DEFAULTALBEDO_PNG, DEFAULTALBEDO_PNG_LENGTH));
             folder.resources.push_back(resource);
+            ImGui::EndPopup();
             return;
         }
         
@@ -244,6 +248,7 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             resource.script->name = "Script #" + std::to_string(Hymn().scriptNumber++);
             Hymn().scripts.push_back(resource.script);
             folder.resources.push_back(resource);
+            ImGui::EndPopup();
             return;
         }
         
@@ -255,6 +260,7 @@ void ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, cons
             resource.sound->path = path + "/";
             resource.sound->name = "Sound #" + std::to_string(Resources().soundNumber++);
             folder.resources.push_back(resource);
+            ImGui::EndPopup();
             return;
         }
         


### PR DESCRIPTION
Early return causes id mismatch in ImGui and isn't necessary.

Fixes #458 