### PR TITLE
Option to create scene when importing model

### DIFF
--- a/src/Editor/GUI/Editors/ModelEditor.cpp
+++ b/src/Editor/GUI/Editors/ModelEditor.cpp
@@ -12,6 +12,7 @@
 #include <Engine/Manager/Managers.hpp>
 #include <Engine/Manager/ResourceManager.hpp>
 #include <Engine/Entity/Entity.hpp>
+#include <Engine/Component/Mesh.hpp>
 
 using namespace GUI;
 
@@ -108,9 +109,14 @@ void ModelEditor::Show() {
                     world->CreateRoot();
                     Entity* entity = world->GetRoot()->AddChild(model->name);
                     
+                    Component::Mesh* mesh = entity->AddComponent<Component::Mesh>();
+                    mesh->geometry = model;
+                    
                     world->Save(Hymn().GetPath() + "/" + model->path + model->name + "Scene.json");
                     
                     // Cleanup.
+                    mesh->geometry = nullptr;
+                    mesh->Kill();
                     delete world;
                 }
             }

--- a/src/Editor/GUI/Editors/ModelEditor.cpp
+++ b/src/Editor/GUI/Editors/ModelEditor.cpp
@@ -11,6 +11,7 @@
 #include "../../Resources.hpp"
 #include <Engine/Manager/Managers.hpp>
 #include <Engine/Manager/ResourceManager.hpp>
+#include <Engine/Entity/Entity.hpp>
 
 using namespace GUI;
 
@@ -96,10 +97,21 @@ void ModelEditor::Show() {
                 
                 // Create scene containing an entity with the model and textures.
                 if (createScene) {
+                    // Create resource.
                     ResourceList::Resource resource;
                     resource.type = ResourceList::Resource::SCENE;
                     resource.scene = model->name + "Scene";
                     folder->resources.push_back(resource);
+                    
+                    // Create and save scene.
+                    World* world = new World();
+                    world->CreateRoot();
+                    Entity* entity = world->GetRoot()->AddChild(model->name);
+                    
+                    world->Save(Hymn().GetPath() + "/" + model->path + model->name + "Scene.json");
+                    
+                    // Cleanup.
+                    delete world;
                 }
             }
 

--- a/src/Editor/GUI/Editors/ModelEditor.cpp
+++ b/src/Editor/GUI/Editors/ModelEditor.cpp
@@ -88,13 +88,17 @@ void ModelEditor::Show() {
                 AssetMetaData::GenerateMetaData((destination + ".asset.meta").c_str(), importData);
                 
                 // Import textures.
+                TextureAsset* albedo = nullptr;
+                TextureAsset* normal = nullptr;
+                TextureAsset* roughness = nullptr;
+                TextureAsset* metallic = nullptr;
                 if (importTextures) {
-                    LoadTexture(materials.albedo, "Albedo");
-                    LoadTexture(materials.normal, "Normal");
-                    LoadTexture(materials.roughness, "Roughness");
-                    LoadTexture(materials.metallic, "Metallic");
+                    albedo = LoadTexture(materials.albedo, "Albedo");
+                    normal = LoadTexture(materials.normal, "Normal");
+                    roughness = LoadTexture(materials.roughness, "Roughness");
+                    metallic = LoadTexture(materials.metallic, "Metallic");
                 }
-
+                
                 delete importData;
                 
                 // Create scene containing an entity with the model and textures.
@@ -114,12 +118,24 @@ void ModelEditor::Show() {
                     mesh->geometry = model;
                     
                     Component::Material* material = entity->AddComponent<Component::Material>();
+                    if (albedo != nullptr)
+                        material->albedo = albedo;
+                    if (normal != nullptr)
+                        material->normal = normal;
+                    if (roughness != nullptr)
+                        material->roughness = roughness;
+                    if (metallic != nullptr)
+                        material->metallic = metallic;
                     
                     world->Save(Hymn().GetPath() + "/" + model->path + model->name + "Scene.json");
                     
                     // Cleanup.
                     mesh->geometry = nullptr;
                     mesh->Kill();
+                    material->albedo = nullptr;
+                    material->normal = nullptr;
+                    material->roughness = nullptr;
+                    material->metallic = nullptr;
                     material->Kill();
                     delete world;
                 }
@@ -213,7 +229,7 @@ void ModelEditor::RefreshImportSettings() {
     }
 }
 
-void ModelEditor::LoadTexture(const std::string& path, const std::string& name) {
+TextureAsset* ModelEditor::LoadTexture(const std::string& path, const std::string& name) {
     if (!path.empty()) {
         std::string textureName = model->name + name;
         std::string src = FileSystem::GetDirectory(source) + path;
@@ -227,5 +243,9 @@ void ModelEditor::LoadTexture(const std::string& path, const std::string& name) 
         resource.type = ResourceList::Resource::TEXTURE;
         resource.texture = Managers().resourceManager->CreateTextureAsset(dest);
         folder->resources.push_back(resource);
+        
+        return resource.texture;
     }
+    
+    return nullptr;
 }

--- a/src/Editor/GUI/Editors/ModelEditor.cpp
+++ b/src/Editor/GUI/Editors/ModelEditor.cpp
@@ -13,6 +13,7 @@
 #include <Engine/Manager/ResourceManager.hpp>
 #include <Engine/Entity/Entity.hpp>
 #include <Engine/Component/Mesh.hpp>
+#include <Engine/Component/Material.hpp>
 
 using namespace GUI;
 
@@ -112,11 +113,14 @@ void ModelEditor::Show() {
                     Component::Mesh* mesh = entity->AddComponent<Component::Mesh>();
                     mesh->geometry = model;
                     
+                    Component::Material* material = entity->AddComponent<Component::Material>();
+                    
                     world->Save(Hymn().GetPath() + "/" + model->path + model->name + "Scene.json");
                     
                     // Cleanup.
                     mesh->geometry = nullptr;
                     mesh->Kill();
+                    material->Kill();
                     delete world;
                 }
             }

--- a/src/Editor/GUI/Editors/ModelEditor.cpp
+++ b/src/Editor/GUI/Editors/ModelEditor.cpp
@@ -63,6 +63,7 @@ void ModelEditor::Show() {
             ImGui::Checkbox("Import Tangents", &importTangents);
             ImGui::Checkbox("Import Textures", &importTextures);
             ImGui::Checkbox("Flip UVs", &flipUVs);
+            ImGui::Checkbox("Create scene", &createScene);
 
             std::string button = isImported ? "Re-import" : "Import";
 
@@ -92,6 +93,14 @@ void ModelEditor::Show() {
                 }
 
                 delete importData;
+                
+                // Create scene containing an entity with the model and textures.
+                if (createScene) {
+                    ResourceList::Resource resource;
+                    resource.type = ResourceList::Resource::SCENE;
+                    resource.scene = model->name + "Scene";
+                    folder->resources.push_back(resource);
+                }
             }
 
             if (isImported)

--- a/src/Editor/GUI/Editors/ModelEditor.hpp
+++ b/src/Editor/GUI/Editors/ModelEditor.hpp
@@ -47,7 +47,7 @@ namespace GUI {
         private:
             void FileSelected(const std::string& file);
             void RefreshImportSettings();
-            void LoadTexture(const std::string& path, const std::string& name);
+            TextureAsset* LoadTexture(const std::string& path, const std::string& name);
             
             ResourceList::ResourceFolder* folder = nullptr;
             Geometry::Model* model = nullptr;

--- a/src/Editor/GUI/Editors/ModelEditor.hpp
+++ b/src/Editor/GUI/Editors/ModelEditor.hpp
@@ -70,5 +70,6 @@ namespace GUI {
             bool importTangents = true;
             bool importTextures = false;
             bool flipUVs = false;
+            bool createScene = false;
     };
 }


### PR DESCRIPTION
When importing a model, allow the user to create a scene containing an entity with a mesh and a material component bound to the imported model and its textures (if textures were imported).

Fixes #353 