### PR TITLE
Fix setting incorrect active scene

### DIFF
--- a/src/Editor/GUI/Editors/SceneEditor.cpp
+++ b/src/Editor/GUI/Editors/SceneEditor.cpp
@@ -25,7 +25,7 @@ void SceneEditor::Show() {
     if (ImGui::Begin(("Scene: " + *scene + "###Scene").c_str(), &visible, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_ShowBorders)) {
         ImGui::InputText("Name", name, 128);
         *scene = name;
-        Resources().activeScene = name;
+        Resources().activeScene = path + "/" + name;
         
         // Entities.
         entityPressed = false;


### PR DESCRIPTION
Active scene is no longer set to an incorrect value when opening a scene.