### PR TITLE
Improve grid settings

### DIFF
--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -7,6 +7,7 @@
 #include <Engine/Hymn.hpp>
 #include <Engine/Manager/Managers.hpp>
 #include <Engine/Manager/ScriptManager.hpp>
+#include <Engine/Manager/DebugDrawingManager.hpp>
 #include <Engine/Util/FileSystem.hpp>
 #include <Engine/MainWindow.hpp>
 #include <Engine/Component/DirectionalLight.hpp>
@@ -152,6 +153,7 @@ void Editor::Show(float deltaTime) {
         
         // Show grid settings window.
         ShowGridSettings();
+        CreateGrid(Hymn().gridSettings.gridSize);
 
         // Control the editor camera.
         ControlEditorCamera(deltaTime);
@@ -463,6 +465,26 @@ void Editor::ShowGridSettings() {
         ImGui::Checkbox("Grid Snap", &Hymn().gridSettings.gridSnap);
         ImGui::DragInt("Snap Option", &Hymn().gridSettings.snapOption, (float)Hymn().gridSettings.snapOption * 10, 1, 100);
         ImGui::End();
+    }
+}
+
+void Editor::CreateGrid(int size) {
+    glm::vec2 gridWidthDepth(10.0f, 10.0f);
+    gridWidthDepth.x = (gridWidthDepth.x * size);
+    gridWidthDepth.y = (gridWidthDepth.y * size);
+    
+    float xStart = (-gridWidthDepth.x / 2);
+    float xEnd = (gridWidthDepth.x / 2);
+    float zStart = (-gridWidthDepth.y / 2);
+    float zEnd = (gridWidthDepth.y / 2);
+    
+    if (size <= 100 && size > 0) {
+        for (int i = 0; i < (size + size + 1); i++) {
+            Managers().debugDrawingManager->AddLine(glm::vec3(xStart, 0.0f, -gridWidthDepth.y / (2)), glm::vec3(xStart, 0.0f, zEnd), glm::vec3(0.1f, 0.1f, 0.5f), 3.0f);
+            Managers().debugDrawingManager->AddLine(glm::vec3(-gridWidthDepth.x / (2), 0.0f, zStart), glm::vec3(xEnd, 0.0f, zStart), glm::vec3(0.5f, 0.1f, 0.1f), 3.0f);
+            xStart += (gridWidthDepth.x / 2) / size;
+            zStart += (gridWidthDepth.y / 2) / size;
+        }
     }
 }
 

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -124,95 +124,9 @@ void Editor::Show(float deltaTime) {
         }
     } else {
         bool play = false;
-
-        ImVec2 size(MainWindow::GetInstance()->GetSize().x, MainWindow::GetInstance()->GetSize().y);
-
+        
         // Main menu bar.
-        if (ImGui::BeginMainMenuBar()) {
-
-            // File menu.
-            if (ImGui::BeginMenu("File")) {
-                if (ImGui::MenuItem("New Hymn", "CTRL+N"))
-                    NewHymn();
-
-                if (ImGui::MenuItem("Open Hymn", "CTRL+O"))
-                    OpenHymn();
-
-                if (Hymn().GetPath() != "") {
-                    if (ImGui::MenuItem("Save Hymn", "CTRL+S"))
-                        Save();
-                }
-
-                ImGui::Separator();
-
-                if (ImGui::MenuItem("Settings"))
-                    settingsWindow.SetVisible(true);
-
-                ImGui::EndMenu();
-            }
-
-            // View menu.
-            if (ImGui::BeginMenu("View")) {
-                ImGui::MenuItem("Grid Settings", "", &showGridSettings);
-                EditorSettings::GetInstance().SetBool("Grid Settings", showGridSettings);
-
-                static bool soundSources = EditorSettings::GetInstance().GetBool("Sound Source Icons");
-                ImGui::MenuItem("Sound Sources", "", &soundSources);
-                EditorSettings::GetInstance().SetBool("Sound Source Icons", soundSources);
-
-                static bool particleEmitters = EditorSettings::GetInstance().GetBool("Particle Emitter Icons");
-                ImGui::MenuItem("Particle Emitters", "", &particleEmitters);
-                EditorSettings::GetInstance().SetBool("Particle Emitter Icons", particleEmitters);
-
-                static bool lightSources = EditorSettings::GetInstance().GetBool("Light Source Icons");
-                ImGui::MenuItem("Light Sources", "", &lightSources);
-                EditorSettings::GetInstance().SetBool("Light Source Icons", lightSources);
-
-                static bool cameras = EditorSettings::GetInstance().GetBool("Camera Icons");
-                ImGui::MenuItem("Cameras", "", &cameras);
-                EditorSettings::GetInstance().SetBool("Camera Icons", cameras);
-
-                static bool physics = EditorSettings::GetInstance().GetBool("Physics Volumes");
-                ImGui::MenuItem("Physics", "", &physics);
-                EditorSettings::GetInstance().SetBool("Physics Volumes", physics);
-
-                ImGui::EndMenu();
-            }
-
-            if (Hymn().GetPath() != "") {
-                // Play
-                if (ImGui::BeginMenu("Play")) {
-                    if (ImGui::MenuItem("Play", "F5"))
-                        play = true;
-
-                    ImGui::EndMenu();
-                }
-
-                // Hymn
-                if (ImGui::BeginMenu("Hymn")) {
-                    if (ImGui::MenuItem("Input"))
-                        inputWindow.SetVisible(true);
-
-                    if (ImGui::MenuItem("Filters"))
-                        filtersWindow.SetVisible(true);
-
-                    ImGui::EndMenu();
-                }
-
-                if (Input()->Triggered(InputHandler::ZOOM)) {
-                    if (resourceView.GetScene().entityEditor.GetEntity() != nullptr) {
-                        const glm::vec3 tempPos = resourceView.GetScene().entityEditor.GetEntity()->GetWorldPosition();
-                        cameraEntity->position = tempPos + glm::vec3(0, 7, 7);
-                        cameraEntity->rotation = glm::vec3(0, 45, 1);
-                    }
-                }
-
-                // Editor Camera Coordinates
-                ImGui::SameLine(size.x - 280); ImGui::Text("X: %f, Y: %f, Z: %f", cameraEntity->GetWorldPosition().x, cameraEntity->GetWorldPosition().y, cameraEntity->GetWorldPosition().z);
-            }
-
-            ImGui::EndMainMenuBar();
-        }
+        ShowMainMenuBar(play);
 
         // Show hymn selection window.
         if (selectHymnWindow.IsVisible()) {
@@ -533,6 +447,96 @@ void Editor::SetVisible(bool visible) {
 
 Entity* Editor::GetCamera() const {
     return cameraEntity;
+}
+
+void Editor::ShowMainMenuBar(bool& play) {
+    ImVec2 size(MainWindow::GetInstance()->GetSize().x, MainWindow::GetInstance()->GetSize().y);
+    
+    // Main menu bar.
+    if (ImGui::BeginMainMenuBar()) {
+        // File menu.
+        if (ImGui::BeginMenu("File")) {
+            if (ImGui::MenuItem("New Hymn", "CTRL+N"))
+                NewHymn();
+
+            if (ImGui::MenuItem("Open Hymn", "CTRL+O"))
+                OpenHymn();
+
+            if (Hymn().GetPath() != "") {
+                if (ImGui::MenuItem("Save Hymn", "CTRL+S"))
+                    Save();
+            }
+
+            ImGui::Separator();
+
+            if (ImGui::MenuItem("Settings"))
+                settingsWindow.SetVisible(true);
+
+            ImGui::EndMenu();
+        }
+
+        // View menu.
+        if (ImGui::BeginMenu("View")) {
+            ImGui::MenuItem("Grid Settings", "", &showGridSettings);
+            EditorSettings::GetInstance().SetBool("Grid Settings", showGridSettings);
+
+            static bool soundSources = EditorSettings::GetInstance().GetBool("Sound Source Icons");
+            ImGui::MenuItem("Sound Sources", "", &soundSources);
+            EditorSettings::GetInstance().SetBool("Sound Source Icons", soundSources);
+
+            static bool particleEmitters = EditorSettings::GetInstance().GetBool("Particle Emitter Icons");
+            ImGui::MenuItem("Particle Emitters", "", &particleEmitters);
+            EditorSettings::GetInstance().SetBool("Particle Emitter Icons", particleEmitters);
+
+            static bool lightSources = EditorSettings::GetInstance().GetBool("Light Source Icons");
+            ImGui::MenuItem("Light Sources", "", &lightSources);
+            EditorSettings::GetInstance().SetBool("Light Source Icons", lightSources);
+
+            static bool cameras = EditorSettings::GetInstance().GetBool("Camera Icons");
+            ImGui::MenuItem("Cameras", "", &cameras);
+            EditorSettings::GetInstance().SetBool("Camera Icons", cameras);
+
+            static bool physics = EditorSettings::GetInstance().GetBool("Physics Volumes");
+            ImGui::MenuItem("Physics", "", &physics);
+            EditorSettings::GetInstance().SetBool("Physics Volumes", physics);
+
+            ImGui::EndMenu();
+        }
+
+        if (Hymn().GetPath() != "") {
+            // Play
+            if (ImGui::BeginMenu("Play")) {
+                if (ImGui::MenuItem("Play", "F5"))
+                    play = true;
+
+                ImGui::EndMenu();
+            }
+
+            // Hymn
+            if (ImGui::BeginMenu("Hymn")) {
+                if (ImGui::MenuItem("Input"))
+                    inputWindow.SetVisible(true);
+
+                if (ImGui::MenuItem("Filters"))
+                    filtersWindow.SetVisible(true);
+
+                ImGui::EndMenu();
+            }
+
+            if (Input()->Triggered(InputHandler::ZOOM)) {
+                if (resourceView.GetScene().entityEditor.GetEntity() != nullptr) {
+                    const glm::vec3 tempPos = resourceView.GetScene().entityEditor.GetEntity()->GetWorldPosition();
+                    cameraEntity->position = tempPos + glm::vec3(0, 7, 7);
+                    cameraEntity->rotation = glm::vec3(0, 45, 1);
+                }
+            }
+
+            // Editor Camera Coordinates
+            ImGui::SameLine(size.x - 280); ImGui::Text("X: %f, Y: %f, Z: %f", cameraEntity->GetWorldPosition().x, cameraEntity->GetWorldPosition().y, cameraEntity->GetWorldPosition().z);
+        }
+
+        ImGui::EndMainMenuBar();
+    }
 }
 
 void Editor::ShowGridSettings() {

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -156,41 +156,8 @@ void Editor::Show(float deltaTime) {
         // Control the editor camera.
         ControlEditorCamera(deltaTime);
 
-        // Mouse ray.
-        if (Input()->Triggered(InputHandler::SELECT) && !ImGui::IsMouseHoveringAnyWindow()) {
-            mousePicker.UpdateProjectionMatrix(cameraEntity->GetComponent < Component::Lens>()->GetProjection(glm::vec2(MainWindow::GetInstance()->GetSize().x, MainWindow::GetInstance()->GetSize().y)));
-            mousePicker.Update();
-            float lastDistance = INFINITY;
-            int entityIndex = 0;
-            int entityAmount = Hymn().world.GetEntities().size();
-            for (int i = 0; i < entityAmount; ++i) {
-                selectedEntity = Hymn().world.GetEntities().at(i);
-                if (selectedEntity->GetComponent<Component::Mesh>() != nullptr) {
-                    selectedEntity->GetComponent<Component::Mesh>()->SetSelected(false);
-                    float intersectDistance = 0.0f;
-                    if (rayIntersector.RayOBBIntersect(cameraEntity->GetWorldPosition(), mousePicker.GetCurrentRay(),
-                        selectedEntity->GetComponent<Component::Mesh>()->geometry->GetAxisAlignedBoundingBox(),
-                        selectedEntity->GetModelMatrix(), intersectDistance)) {
-                        if (intersectDistance < lastDistance) {
-                            lastDistance = intersectDistance;
-                            entityIndex = i;
-                            if (entityAmount - i == 1) {
-                                resourceView.GetScene().entityEditor.SetEntity(Hymn().world.GetEntities().at(entityIndex));
-                                resourceView.GetScene().entityEditor.SetVisible(true);
-                                selectedEntity->GetComponent<Component::Mesh>()->SetSelected(true);
-                                break;
-                            }
-                          
-                        } else if (intersectDistance > 0.0f) {
-                            resourceView.GetScene().entityEditor.SetEntity(Hymn().world.GetEntities().at(entityIndex));
-                            resourceView.GetScene().entityEditor.SetVisible(true);
-                            selectedEntity->GetComponent<Component::Mesh>()->SetSelected(true);
-                            break;
-                        }
-                    }
-                }
-            }
-        }
+        // Select entity by clicking on it with the mouse.
+        Picking();
 
         // Move camera position and rotation to fixate on selected object.
         if (Input()->Triggered(InputHandler::FOCUS)) {
@@ -551,6 +518,43 @@ void Editor::ControlEditorCamera(float deltaTime) {
         } else {
             cameraEntity->position += constantSpeed * backward * static_cast<float>(Input()->Pressed(InputHandler::BACKWARD) - Input()->Pressed(InputHandler::FORWARD));
             cameraEntity->position += constantSpeed * right * static_cast<float>(Input()->Pressed(InputHandler::RIGHT) - Input()->Pressed(InputHandler::LEFT));
+        }
+    }
+}
+
+void Editor::Picking() {
+    if (Input()->Triggered(InputHandler::SELECT) && !ImGui::IsMouseHoveringAnyWindow()) {
+        mousePicker.UpdateProjectionMatrix(cameraEntity->GetComponent < Component::Lens>()->GetProjection(glm::vec2(MainWindow::GetInstance()->GetSize().x, MainWindow::GetInstance()->GetSize().y)));
+        mousePicker.Update();
+        float lastDistance = INFINITY;
+        int entityIndex = 0;
+        int entityAmount = Hymn().world.GetEntities().size();
+        for (int i = 0; i < entityAmount; ++i) {
+            selectedEntity = Hymn().world.GetEntities().at(i);
+            if (selectedEntity->GetComponent<Component::Mesh>() != nullptr) {
+                selectedEntity->GetComponent<Component::Mesh>()->SetSelected(false);
+                float intersectDistance = 0.0f;
+                if (rayIntersector.RayOBBIntersect(cameraEntity->GetWorldPosition(), mousePicker.GetCurrentRay(),
+                    selectedEntity->GetComponent<Component::Mesh>()->geometry->GetAxisAlignedBoundingBox(),
+                    selectedEntity->GetModelMatrix(), intersectDistance)) {
+                    if (intersectDistance < lastDistance) {
+                        lastDistance = intersectDistance;
+                        entityIndex = i;
+                        if (entityAmount - i == 1) {
+                            resourceView.GetScene().entityEditor.SetEntity(Hymn().world.GetEntities().at(entityIndex));
+                            resourceView.GetScene().entityEditor.SetVisible(true);
+                            selectedEntity->GetComponent<Component::Mesh>()->SetSelected(true);
+                            break;
+                        }
+                      
+                    } else if (intersectDistance > 0.0f) {
+                        resourceView.GetScene().entityEditor.SetEntity(Hymn().world.GetEntities().at(entityIndex));
+                        resourceView.GetScene().entityEditor.SetVisible(true);
+                        selectedEntity->GetComponent<Component::Mesh>()->SetSelected(true);
+                        break;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -468,7 +468,7 @@ void Editor::ShowGridSettings() {
         EditorSettings::GetInstance().SetLong("Grid Size", gridSettings.gridSize);
         ImGui::Checkbox("Grid Snap", &gridSettings.gridSnap);
         EditorSettings::GetInstance().SetBool("Grid Snap", gridSettings.gridSnap);
-        ImGui::DragInt("Snap Size", &gridSettings.snapOption, (float)gridSettings.snapOption * 10, 1, 100);
+        ImGui::DragInt("Snap Size", &gridSettings.snapOption, 1.0f, 1, 100);
         EditorSettings::GetInstance().SetLong("Grid Snap Size", gridSettings.snapOption);
         ImGui::End();
     }

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -77,6 +77,9 @@ Editor::Editor() {
     
     // Load settings.
     showGridSettings = EditorSettings::GetInstance().GetBool("Grid Settings");
+    gridSettings.gridSize = EditorSettings::GetInstance().GetLong("Grid Size");
+    gridSettings.gridSnap = EditorSettings::GetInstance().GetBool("Grid Snap");
+    gridSettings.snapOption = EditorSettings::GetInstance().GetLong("Grid Snap Size");
 
     // Ray mouse.
     mousePicker = MousePicking(cameraEntity, cameraEntity->GetComponent < Component::Lens>()->GetProjection(glm::vec2(MainWindow::GetInstance()->GetSize().x, MainWindow::GetInstance()->GetSize().y)));

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -464,11 +464,11 @@ void Editor::ShowGridSettings() {
         ImGui::SetNextWindowPos(ImVec2(1275, 25));
         ImGui::SetNextWindowSizeConstraints(ImVec2(255, 150), ImVec2(255, 150));
         ImGui::Begin("Grid Settings", &showGridSettings, ImGuiWindowFlags_NoTitleBar);
-        ImGui::DragInt("Grid Scale", &gridSettings.gridSize, 1.0f, 0, 100);
+        ImGui::DragInt("Grid Size", &gridSettings.gridSize, 1.0f, 0, 100);
         EditorSettings::GetInstance().SetLong("Grid Size", gridSettings.gridSize);
         ImGui::Checkbox("Grid Snap", &gridSettings.gridSnap);
         EditorSettings::GetInstance().SetBool("Grid Snap", gridSettings.gridSnap);
-        ImGui::DragInt("Snap Option", &gridSettings.snapOption, (float)gridSettings.snapOption * 10, 1, 100);
+        ImGui::DragInt("Snap Size", &gridSettings.snapOption, (float)gridSettings.snapOption * 10, 1, 100);
         EditorSettings::GetInstance().SetLong("Grid Snap Size", gridSettings.snapOption);
         ImGui::End();
     }

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -158,34 +158,10 @@ void Editor::Show(float deltaTime) {
 
         // Select entity by clicking on it with the mouse.
         Picking();
-
+        
         // Move camera position and rotation to fixate on selected object.
-        if (Input()->Triggered(InputHandler::FOCUS)) {
-
-            if (selectedEntity != NULL) {
-
-                glm::vec3 backward = glm::normalize(cameraEntity->position - selectedEntity->position);
-
-                while (glm::length(selectedEntity->position - cameraEntity->position) > 10) {
-                    cameraEntity->position -= backward;
-                }
-
-                while (glm::length(selectedEntity->position - cameraEntity->position) < 10) {
-                    cameraEntity->position += backward;
-                }
-
-                glm::vec3 camDirection = selectedEntity->position - cameraEntity->position;
-                glm::normalize(camDirection);
-
-                float yaw = std::atan2(camDirection.x, -camDirection.z);
-                cameraEntity->rotation.x = glm::degrees(yaw);
-
-                float xz = std::sqrt(camDirection.x * camDirection.x + camDirection.z * camDirection.z);
-                float pitch = std::atan2(-camDirection.y, xz);
-                cameraEntity->rotation.y = glm::degrees(pitch);
-            }
-        }
-
+        Focus();
+        
         // Scroll zoom.
         if (Input()->GetScrollDown()) {
             if (!ImGui::IsMouseHoveringAnyWindow()) {
@@ -240,7 +216,7 @@ void Editor::Show(float deltaTime) {
 
     Entity* currentEntity = resourceView.GetScene().entityEditor.GetEntity();
 
-    if (currentEntity != NULL) {
+    if (currentEntity != nullptr) {
         currentEntityMatrix = currentEntity->GetLocalMatrix();
 
         // Change operation based on key input.
@@ -555,6 +531,30 @@ void Editor::Picking() {
                     }
                 }
             }
+        }
+    }
+}
+
+void Editor::Focus() {
+    if (Input()->Triggered(InputHandler::FOCUS)) {
+        if (selectedEntity != nullptr) {
+            glm::vec3 backward = glm::normalize(cameraEntity->position - selectedEntity->position);
+            
+            while (glm::length(selectedEntity->position - cameraEntity->position) > 10)
+                cameraEntity->position -= backward;
+            
+            while (glm::length(selectedEntity->position - cameraEntity->position) < 10)
+                cameraEntity->position += backward;
+            
+            glm::vec3 camDirection = selectedEntity->position - cameraEntity->position;
+            glm::normalize(camDirection);
+
+            float yaw = std::atan2(camDirection.x, -camDirection.z);
+            cameraEntity->rotation.x = glm::degrees(yaw);
+
+            float xz = std::sqrt(camDirection.x * camDirection.x + camDirection.z * camDirection.z);
+            float pitch = std::atan2(-camDirection.y, xz);
+            cameraEntity->rotation.y = glm::degrees(pitch);
         }
     }
 }

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -154,35 +154,7 @@ void Editor::Show(float deltaTime) {
         ShowGridSettings();
 
         // Control the editor camera.
-        if (Input()->Pressed(InputHandler::CAMERA)) {
-            if (Input()->Triggered(InputHandler::CAMERA)) {
-                lastX = Input()->GetCursorX();
-                lastY = Input()->GetCursorY();
-            }
-
-            float sensitivity = 0.3f;
-            cameraEntity->rotation.x += sensitivity * (Input()->GetCursorX() - lastX);
-            cameraEntity->rotation.y += sensitivity * (Input()->GetCursorY() - lastY);
-
-            lastX = Input()->GetCursorX();
-            lastY = Input()->GetCursorY();
-
-            glm::mat4 orientation = cameraEntity->GetCameraOrientation();
-            glm::vec3 backward(orientation[0][2], orientation[1][2], orientation[2][2]);
-            glm::vec3 right(orientation[0][0], orientation[1][0], orientation[2][0]);
-
-            // Move speed scaling.
-            float speed = 10.0f * deltaTime * (glm::abs(cameraEntity->position.y) / 10.0f);
-            float constantSpeed = 10.0f * deltaTime;
-
-            if (cameraEntity->position.y > 10.0f || cameraEntity->position.y < -10.0f) {
-                cameraEntity->position += speed * backward * static_cast<float>(Input()->Pressed(InputHandler::BACKWARD) - Input()->Pressed(InputHandler::FORWARD));
-                cameraEntity->position += speed * right * static_cast<float>(Input()->Pressed(InputHandler::RIGHT) - Input()->Pressed(InputHandler::LEFT));
-            } else {
-                cameraEntity->position += constantSpeed * backward * static_cast<float>(Input()->Pressed(InputHandler::BACKWARD) - Input()->Pressed(InputHandler::FORWARD));
-                cameraEntity->position += constantSpeed * right * static_cast<float>(Input()->Pressed(InputHandler::RIGHT) - Input()->Pressed(InputHandler::LEFT));
-            }
-        }
+        ControlEditorCamera(deltaTime);
 
         // Mouse ray.
         if (Input()->Triggered(InputHandler::SELECT) && !ImGui::IsMouseHoveringAnyWindow()) {
@@ -548,6 +520,38 @@ void Editor::ShowGridSettings() {
         ImGui::Checkbox("Grid Snap", &Hymn().gridSettings.gridSnap);
         ImGui::DragInt("Snap Option", &Hymn().gridSettings.snapOption, (float)Hymn().gridSettings.snapOption * 10, 1, 100);
         ImGui::End();
+    }
+}
+
+void Editor::ControlEditorCamera(float deltaTime) {
+    if (Input()->Pressed(InputHandler::CAMERA)) {
+        if (Input()->Triggered(InputHandler::CAMERA)) {
+            lastX = Input()->GetCursorX();
+            lastY = Input()->GetCursorY();
+        }
+
+        float sensitivity = 0.3f;
+        cameraEntity->rotation.x += sensitivity * (Input()->GetCursorX() - lastX);
+        cameraEntity->rotation.y += sensitivity * (Input()->GetCursorY() - lastY);
+
+        lastX = Input()->GetCursorX();
+        lastY = Input()->GetCursorY();
+
+        glm::mat4 orientation = cameraEntity->GetCameraOrientation();
+        glm::vec3 backward(orientation[0][2], orientation[1][2], orientation[2][2]);
+        glm::vec3 right(orientation[0][0], orientation[1][0], orientation[2][0]);
+
+        // Move speed scaling.
+        float speed = 10.0f * deltaTime * (glm::abs(cameraEntity->position.y) / 10.0f);
+        float constantSpeed = 10.0f * deltaTime;
+
+        if (cameraEntity->position.y > 10.0f || cameraEntity->position.y < -10.0f) {
+            cameraEntity->position += speed * backward * static_cast<float>(Input()->Pressed(InputHandler::BACKWARD) - Input()->Pressed(InputHandler::FORWARD));
+            cameraEntity->position += speed * right * static_cast<float>(Input()->Pressed(InputHandler::RIGHT) - Input()->Pressed(InputHandler::LEFT));
+        } else {
+            cameraEntity->position += constantSpeed * backward * static_cast<float>(Input()->Pressed(InputHandler::BACKWARD) - Input()->Pressed(InputHandler::FORWARD));
+            cameraEntity->position += constantSpeed * right * static_cast<float>(Input()->Pressed(InputHandler::RIGHT) - Input()->Pressed(InputHandler::LEFT));
+        }
     }
 }
 

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -405,7 +405,6 @@ void Editor::Show(float deltaTime) {
         glm::mat4 viewMatrix = cameraEntity->GetCameraOrientation() * glm::translate(glm::mat4(), -cameraEntity->GetWorldPosition());
 
         // Identity matrix.
-        glm::mat4 identity = glm::mat4();
         float translationValue[3] = { currentEntity->position.x, currentEntity->position.y, currentEntity->position.z };
         float scaleValue[3] = { currentEntity->scale.x, currentEntity->scale.y, currentEntity->scale.z };
         float rotationValue[3] = { currentEntity->rotation.x, currentEntity->rotation.y, currentEntity->rotation.z };

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -73,6 +73,9 @@ Editor::Editor() {
     savePromptAnswered = false;
     savePromtWindow.SetTitle("Save before you quit?");
     close = false;
+    
+    // Load settings.
+    showGridSettings = EditorSettings::GetInstance().GetBool("Grid Settings");
 
     // Ray mouse.
     mousePicker = MousePicking(cameraEntity, cameraEntity->GetComponent < Component::Lens>()->GetProjection(glm::vec2(MainWindow::GetInstance()->GetSize().x, MainWindow::GetInstance()->GetSize().y)));
@@ -150,7 +153,6 @@ void Editor::Show(float deltaTime) {
 
             // View menu.
             if (ImGui::BeginMenu("View")) {
-                static bool showGridSettings = EditorSettings::GetInstance().GetBool("Grid Settings");
                 ImGui::MenuItem("Grid Settings", "", &showGridSettings);
                 EditorSettings::GetInstance().SetBool("Grid Settings", showGridSettings);
 
@@ -233,6 +235,9 @@ void Editor::Show(float deltaTime) {
         if (settingsWindow.IsVisible()) {
             settingsWindow.Show();
         }
+        
+        // Show grid settings window.
+        ShowGridSettings();
 
         // Control the editor camera.
         if (Input()->Pressed(InputHandler::CAMERA)) {
@@ -529,6 +534,18 @@ void Editor::SetVisible(bool visible) {
 
 Entity* Editor::GetCamera() const {
     return cameraEntity;
+}
+
+void Editor::ShowGridSettings() {
+    if (showGridSettings) {
+        ImGui::SetNextWindowPos(ImVec2(1275, 25));
+        ImGui::SetNextWindowSizeConstraints(ImVec2(255, 150), ImVec2(255, 150));
+        ImGui::Begin("Grid Settings", &showGridSettings, ImGuiWindowFlags_NoTitleBar);
+        ImGui::DragInt("Grid Scale", &Hymn().gridSettings.gridSize, 1.0f, 0, 100);
+        ImGui::Checkbox("Grid Snap", &Hymn().gridSettings.gridSnap);
+        ImGui::DragInt("Snap Option", &Hymn().gridSettings.snapOption, (float)Hymn().gridSettings.snapOption * 10, 1, 100);
+        ImGui::End();
+    }
 }
 
 void Editor::Play() {

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -153,7 +153,7 @@ void Editor::Show(float deltaTime) {
         
         // Show grid settings window.
         ShowGridSettings();
-        CreateGrid(Hymn().gridSettings.gridSize);
+        CreateGrid(gridSettings.gridSize);
 
         // Control the editor camera.
         ControlEditorCamera(deltaTime);
@@ -461,9 +461,12 @@ void Editor::ShowGridSettings() {
         ImGui::SetNextWindowPos(ImVec2(1275, 25));
         ImGui::SetNextWindowSizeConstraints(ImVec2(255, 150), ImVec2(255, 150));
         ImGui::Begin("Grid Settings", &showGridSettings, ImGuiWindowFlags_NoTitleBar);
-        ImGui::DragInt("Grid Scale", &Hymn().gridSettings.gridSize, 1.0f, 0, 100);
-        ImGui::Checkbox("Grid Snap", &Hymn().gridSettings.gridSnap);
-        ImGui::DragInt("Snap Option", &Hymn().gridSettings.snapOption, (float)Hymn().gridSettings.snapOption * 10, 1, 100);
+        ImGui::DragInt("Grid Scale", &gridSettings.gridSize, 1.0f, 0, 100);
+        EditorSettings::GetInstance().SetLong("Grid Size", gridSettings.gridSize);
+        ImGui::Checkbox("Grid Snap", &gridSettings.gridSnap);
+        EditorSettings::GetInstance().SetBool("Grid Snap", gridSettings.gridSnap);
+        ImGui::DragInt("Snap Option", &gridSettings.snapOption, (float)gridSettings.snapOption * 10, 1, 100);
+        EditorSettings::GetInstance().SetLong("Grid Snap Size", gridSettings.snapOption);
         ImGui::End();
     }
 }

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -89,9 +89,9 @@ class Editor {
         void LoadActiveScene();
         
         struct GridSettings {
-            int gridSize = 0;
-            bool gridSnap = true;
-            int snapOption = 100;
+            int gridSize;
+            bool gridSnap;
+            int snapOption;
         } gridSettings;
         
         bool visible = true;

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -74,6 +74,7 @@ class Editor {
         Entity* GetCamera() const;
         
     private:
+        void ShowMainMenuBar(bool& play);
         void ShowGridSettings();
         void Play();
         void NewHymn();

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -74,6 +74,7 @@ class Editor {
         Entity* GetCamera() const;
         
     private:
+        void ShowGridSettings();
         void Play();
         void NewHymn();
         void NewHymnClosed(const std::string& hymn);
@@ -91,6 +92,7 @@ class Editor {
 
         bool close;
         bool savePromptAnswered;
+        bool showGridSettings;
 
         Json::Value sceneState;
         

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -77,6 +77,7 @@ class Editor {
         void ShowMainMenuBar(bool& play);
         void ShowGridSettings();
         void ControlEditorCamera(float deltaTime);
+        void Picking();
         
         void Play();
         void NewHymn();

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -76,6 +76,7 @@ class Editor {
     private:
         void ShowMainMenuBar(bool& play);
         void ShowGridSettings();
+        void CreateGrid(int size);
         void ControlEditorCamera(float deltaTime);
         void Picking();
         void Focus();

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -78,6 +78,7 @@ class Editor {
         void ShowGridSettings();
         void ControlEditorCamera(float deltaTime);
         void Picking();
+        void Focus();
         
         void Play();
         void NewHymn();

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -76,6 +76,8 @@ class Editor {
     private:
         void ShowMainMenuBar(bool& play);
         void ShowGridSettings();
+        void ControlEditorCamera(float deltaTime);
+        
         void Play();
         void NewHymn();
         void NewHymnClosed(const std::string& hymn);

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -88,6 +88,12 @@ class Editor {
         void OpenHymnClosed(const std::string& hymn);
         void LoadActiveScene();
         
+        struct GridSettings {
+            int gridSize = 0;
+            bool gridSnap = true;
+            int snapOption = 100;
+        } gridSettings;
+        
         bool visible = true;
         GUI::SelectHymnWindow selectHymnWindow;
         GUI::InputWindow inputWindow;

--- a/src/Editor/GUI/Editors/EntityEditor.cpp
+++ b/src/Editor/GUI/Editors/EntityEditor.cpp
@@ -75,8 +75,8 @@ void EntityEditor::Show() {
         ImGui::ShowHelpMarker("The entity's position, rotation and scale.", 75.f);
         ImGui::Indent();
 
-        if (Hymn().gridSettings.gridSnap) {
-            int toNearest = Hymn().gridSettings.snapOption;
+        if (EditorSettings::GetInstance().GetBool("Grid Snap")) {
+            int toNearest = EditorSettings::GetInstance().GetLong("Grid Snap Size");
 
             int value = entity->position.x;
             int rest = value % toNearest;

--- a/src/Editor/Util/EditorSettings.cpp
+++ b/src/Editor/Util/EditorSettings.cpp
@@ -21,10 +21,10 @@ EditorSettings::EditorSettings() {
     
     AddStringSetting("Text Editor", "Script", "Text Editor", "");
     
-    AddBoolSetting("Grid", "View", "Grid Settings", false);
-    AddLongSetting("Grid", "Size", "Grid Size", 100);
-    AddBoolSetting("Grid", "Snap", "Grid Snap", false);
-    AddLongSetting("Grid", "Snap Size", "Grid Snap size", 100);
+    AddBoolSetting("Grid Settings", "View", "Grid Settings", false);
+    AddLongSetting("Grid Size", "Grid", "Size", 100);
+    AddBoolSetting("Grid Snap", "Grid", "Snap", false);
+    AddLongSetting("Grid Snap Size", "Grid", "Snap Size", 100);
 }
 
 EditorSettings& EditorSettings::GetInstance() {

--- a/src/Editor/Util/EditorSettings.cpp
+++ b/src/Editor/Util/EditorSettings.cpp
@@ -8,8 +8,6 @@ EditorSettings::EditorSettings() {
     
     AddBoolSetting("Logging", "Debug", "Logging", false);
     AddBoolSetting("Debug Context", "Debug", "Debug Context", false);
-    
-    AddBoolSetting("Grid Settings", "View", "Grid Settings", false);
 
     AddLongSetting("Width", "Graphics", "Width", 800);
     AddLongSetting("Height", "Graphics", "Height", 600);
@@ -22,6 +20,11 @@ EditorSettings::EditorSettings() {
     AddBoolSetting("Physics Volumes", "View", "Physics Volumes", true);
     
     AddStringSetting("Text Editor", "Script", "Text Editor", "");
+    
+    AddBoolSetting("Grid", "View", "Grid Settings", false);
+    AddLongSetting("Grid", "Size", "Grid Size", 100);
+    AddBoolSetting("Grid", "Snap", "Grid Snap", false);
+    AddLongSetting("Grid", "Snap Size", "Grid Snap size", 100);
 }
 
 EditorSettings& EditorSettings::GetInstance() {

--- a/src/Editor/Util/EditorSettings.hpp
+++ b/src/Editor/Util/EditorSettings.hpp
@@ -18,6 +18,10 @@
  * Camera Icons           | Show camera icons.               | bool   | true
  * Physics Volumes        | Show physics volumes.            | bool   | true
  * Text Editor            | Path to text editor for scripts. | string | 
+ * Grid Settings          | Whether to show grid settings.   | bool   | false
+ * Grid Size              | Size of the grid.                | long   | 100
+ * Grid Snap              | Snap to grid when moving.        | bool   | false
+ * Grid Snap Size         | Size to snap to.                 | long   | 100
  */
 class EditorSettings : public Settings {
     public:

--- a/src/Editor/main.cpp
+++ b/src/Editor/main.cpp
@@ -127,6 +127,9 @@ int main() {
         lastTimeRender = glfwGetTime();
     }
     
+    // Save editor settings.
+    EditorSettings::GetInstance().Save();
+    
     // Shut down and cleanup.
     ImGuiImplementation::Shutdown();
     delete editor;

--- a/src/Editor/main.cpp
+++ b/src/Editor/main.cpp
@@ -79,7 +79,7 @@ int main() {
                 Managers().particleManager->Update(Hymn().world, deltaTime, true);
 
                 Managers().debugDrawingManager->Update(deltaTime);
-                Hymn().Render(editor->GetCamera(), EditorSettings::GetInstance().GetBool("Sound Source Icons"), EditorSettings::GetInstance().GetBool("Particle Emitter Icons"), EditorSettings::GetInstance().GetBool("Light Source Icons"), EditorSettings::GetInstance().GetBool("Camera Icons"), EditorSettings::GetInstance().GetBool("Physics Volumes"), EditorSettings::GetInstance().GetBool("Grid Settings"));
+                Hymn().Render(editor->GetCamera(), EditorSettings::GetInstance().GetBool("Sound Source Icons"), EditorSettings::GetInstance().GetBool("Particle Emitter Icons"), EditorSettings::GetInstance().GetBool("Light Source Icons"), EditorSettings::GetInstance().GetBool("Camera Icons"), EditorSettings::GetInstance().GetBool("Physics Volumes"));
 
                 if (window->ShouldClose())
                     editor->Close();

--- a/src/Engine/Hymn.cpp
+++ b/src/Engine/Hymn.cpp
@@ -213,29 +213,8 @@ void ActiveHymn::Render(Entity* camera, bool soundSources, bool particleEmitters
 
     { PROFILE("Render debug entities");
     { GPUPROFILE("Render debug entities", Video::Query::Type::TIME_ELAPSED);
-        CreateGrid(gridSettings.gridSize);
         Managers().debugDrawingManager->Render(camera);
     }
-    }
-}
-
-void ActiveHymn::CreateGrid(int scale) {
-    glm::vec2 gridWidthDepth(10.0f, 10.0f);
-    gridWidthDepth.x = (gridWidthDepth.x * scale);
-    gridWidthDepth.y = (gridWidthDepth.y * scale);
-
-    float xStart = (-gridWidthDepth.x / 2);
-    float xEnd = (gridWidthDepth.x / 2);
-    float zStart = (-gridWidthDepth.y / 2);
-    float zEnd = (gridWidthDepth.y / 2);
-
-    if (scale <= 100 && scale > 0) {
-        for (int i = 0; i < (scale + scale + 1); i++) {
-            Managers().debugDrawingManager->AddLine(glm::vec3(xStart, 0.0f, -gridWidthDepth.y / (2)), glm::vec3(xStart, 0.0f, zEnd), glm::vec3(0.1f, 0.1f, 0.5f), 3.0f);
-            Managers().debugDrawingManager->AddLine(glm::vec3(-gridWidthDepth.x / (2), 0.0f, zStart), glm::vec3(xEnd, 0.0f, zStart), glm::vec3(0.5f, 0.1f, 0.1f), 3.0f);
-            xStart += (gridWidthDepth.x / 2) / scale;
-            zStart += (gridWidthDepth.y / 2) / scale;
-        }
     }
 }
 

--- a/src/Engine/Hymn.cpp
+++ b/src/Engine/Hymn.cpp
@@ -196,7 +196,7 @@ void ActiveHymn::Update(float deltaTime) {
     }
 }
 
-void ActiveHymn::Render(Entity* camera, bool soundSources, bool particleEmitters, bool lightSources, bool cameras, bool physics, bool showGridSettings) {
+void ActiveHymn::Render(Entity* camera, bool soundSources, bool particleEmitters, bool lightSources, bool cameras, bool physics) {
     { PROFILE("Render world");
     { GPUPROFILE("Render world", Video::Query::Type::TIME_ELAPSED);
         Managers().renderManager->Render(world, camera);

--- a/src/Engine/Hymn.cpp
+++ b/src/Engine/Hymn.cpp
@@ -210,16 +210,6 @@ void ActiveHymn::Render(Entity* camera, bool soundSources, bool particleEmitters
         }
         }
     }
-    if (showGridSettings)
-    {
-        ImGui::SetNextWindowPos(ImVec2(1275, 25));
-        ImGui::SetNextWindowSizeConstraints(ImVec2(255, 150), ImVec2(255, 150));
-        ImGui::Begin("Grid Settings", &showGridSettings, ImGuiWindowFlags_NoTitleBar);
-        ImGui::DragInt("Grid Scale", &gridSettings.gridSize, 1.0f, 0, 100);
-        ImGui::Checkbox("Grid Snap", &gridSettings.gridSnap);
-        ImGui::DragInt("Snap Option", &gridSettings.snapOption, (float)gridSettings.snapOption * 10, 1, 100);
-        ImGui::End();
-    }
 
     { PROFILE("Render debug entities");
     { GPUPROFILE("Render debug entities", Video::Query::Type::TIME_ELAPSED);

--- a/src/Engine/Hymn.hpp
+++ b/src/Engine/Hymn.hpp
@@ -71,13 +71,7 @@ class ActiveHymn {
          * @param physics Whether to show physics volumes.
          */
         void Render(Entity* camera = nullptr, bool soundSources = false, bool particleEmitters = false, bool lightSources = false, bool cameras = false, bool physics = false);
-
-        /// Create static grid.
-        /**
-        * @param scale Scales the grid, scale can be a maximum of 100.
-        */
-        void CreateGrid(int scale);
-
+        
         /// The game world.
         World world;
         

--- a/src/Engine/Hymn.hpp
+++ b/src/Engine/Hymn.hpp
@@ -105,12 +105,9 @@ class ActiveHymn {
         /// Grid settings.
         struct GridSettings {
             int gridSize = 0;
-            bool gridSettingsOpen = true;
             bool gridSnap = true;
             int snapOption = 100;
-        };
-
-        GridSettings gridSettings;
+        } gridSettings;
 
         /// Filter settings.
         struct FilterSettings {

--- a/src/Engine/Hymn.hpp
+++ b/src/Engine/Hymn.hpp
@@ -96,13 +96,6 @@ class ActiveHymn {
         /// Default roughness texture.
         TextureAsset* defaultRoughness;
         
-        /// Grid settings.
-        struct GridSettings {
-            int gridSize = 0;
-            bool gridSnap = true;
-            int snapOption = 100;
-        } gridSettings;
-
         /// Filter settings.
         struct FilterSettings {
             /// Whether to enable color.

--- a/src/Engine/Hymn.hpp
+++ b/src/Engine/Hymn.hpp
@@ -70,7 +70,7 @@ class ActiveHymn {
          * @param cameras Whether to show cameras.
          * @param physics Whether to show physics volumes.
          */
-        void Render(Entity* camera = nullptr, bool soundSources = false, bool particleEmitters = false, bool lightSources = false, bool cameras = false, bool physics = false, bool gridSettings = false);
+        void Render(Entity* camera = nullptr, bool soundSources = false, bool particleEmitters = false, bool lightSources = false, bool cameras = false, bool physics = false);
 
         /// Create static grid.
         /**


### PR DESCRIPTION
Save grid settings between runs.
Break Editor::Show down into smaller methods.
Move grid drawing from Engine to Editor.
Rename grid scale to grid size.
More sensible scale on the grid snap slider.

Fixes #483 
Fixes #419 