### PR TITLE
Fix compilation with MinGW

### DIFF
--- a/src/Engine/Manager/VRManager.hpp
+++ b/src/Engine/Manager/VRManager.hpp
@@ -2,7 +2,6 @@
 
 #include <glm/glm.hpp>
 #include <openvr.h>
-#include <openvr_capi.h>
 
 /// Handles communication with VR devices using OpenVR.
 class VRManager {


### PR DESCRIPTION
Remove unused include that breaks MinGW build. openvr_capi.h isn't intended to be used when using the API. It's meant to be used when creating bindings for OpenVR to other languages.