### PR TITLE
Option for grid line width

### DIFF
--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -467,7 +467,7 @@ void Editor::ShowGridSettings() {
         ImGui::Begin("Grid Settings", &showGridSettings, ImGuiWindowFlags_NoTitleBar);
         ImGui::DragInt("Grid Size", &gridSettings.gridSize, 1.0f, 0, 100);
         EditorSettings::GetInstance().SetLong("Grid Size", gridSettings.gridSize);
-        ImGui::DragInt("Line Width", &gridSettings.lineWidth, 1.0f, 1, 5);
+        ImGui::DragInt("Line Width", &gridSettings.lineWidth, 0.1f, 1, 5);
         EditorSettings::GetInstance().SetLong("Grid Line Width", gridSettings.lineWidth);
         ImGui::Checkbox("Grid Snap", &gridSettings.gridSnap);
         EditorSettings::GetInstance().SetBool("Grid Snap", gridSettings.gridSnap);

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -78,6 +78,7 @@ Editor::Editor() {
     // Load settings.
     showGridSettings = EditorSettings::GetInstance().GetBool("Grid Settings");
     gridSettings.gridSize = EditorSettings::GetInstance().GetLong("Grid Size");
+    gridSettings.lineWidth = EditorSettings::GetInstance().GetLong("Grid Line Width");
     gridSettings.gridSnap = EditorSettings::GetInstance().GetBool("Grid Snap");
     gridSettings.snapOption = EditorSettings::GetInstance().GetLong("Grid Snap Size");
 
@@ -466,6 +467,8 @@ void Editor::ShowGridSettings() {
         ImGui::Begin("Grid Settings", &showGridSettings, ImGuiWindowFlags_NoTitleBar);
         ImGui::DragInt("Grid Size", &gridSettings.gridSize, 1.0f, 0, 100);
         EditorSettings::GetInstance().SetLong("Grid Size", gridSettings.gridSize);
+        ImGui::DragInt("Line Width", &gridSettings.lineWidth, 1.0f, 1, 5);
+        EditorSettings::GetInstance().SetLong("Grid Line Width", gridSettings.lineWidth);
         ImGui::Checkbox("Grid Snap", &gridSettings.gridSnap);
         EditorSettings::GetInstance().SetBool("Grid Snap", gridSettings.gridSnap);
         ImGui::DragInt("Snap Size", &gridSettings.snapOption, 1.0f, 1, 100);

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -489,8 +489,8 @@ void Editor::CreateGrid(int size) {
     
     if (size <= 100 && size > 0) {
         for (int i = 0; i < (size + size + 1); i++) {
-            Managers().debugDrawingManager->AddLine(glm::vec3(xStart, 0.0f, -gridWidthDepth.y / (2)), glm::vec3(xStart, 0.0f, zEnd), glm::vec3(0.1f, 0.1f, 0.5f), 3.0f);
-            Managers().debugDrawingManager->AddLine(glm::vec3(-gridWidthDepth.x / (2), 0.0f, zStart), glm::vec3(xEnd, 0.0f, zStart), glm::vec3(0.5f, 0.1f, 0.1f), 3.0f);
+            Managers().debugDrawingManager->AddLine(glm::vec3(xStart, 0.0f, -gridWidthDepth.y / (2)), glm::vec3(xStart, 0.0f, zEnd), glm::vec3(0.1f, 0.1f, 0.5f), static_cast<float>(gridSettings.lineWidth));
+            Managers().debugDrawingManager->AddLine(glm::vec3(-gridWidthDepth.x / (2), 0.0f, zStart), glm::vec3(xEnd, 0.0f, zStart), glm::vec3(0.5f, 0.1f, 0.1f), static_cast<float>(gridSettings.lineWidth));
             xStart += (gridWidthDepth.x / 2) / size;
             zStart += (gridWidthDepth.y / 2) / size;
         }

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -90,6 +90,7 @@ class Editor {
         
         struct GridSettings {
             int gridSize;
+            int lineWidth;
             bool gridSnap;
             int snapOption;
         } gridSettings;

--- a/src/Editor/Util/EditorSettings.cpp
+++ b/src/Editor/Util/EditorSettings.cpp
@@ -23,6 +23,7 @@ EditorSettings::EditorSettings() {
     
     AddBoolSetting("Grid Settings", "View", "Grid Settings", false);
     AddLongSetting("Grid Size", "Grid", "Size", 100);
+    AddLongSetting("Grid Line Width", "Grid", "Line Width", 3);
     AddBoolSetting("Grid Snap", "Grid", "Snap", false);
     AddLongSetting("Grid Snap Size", "Grid", "Snap Size", 100);
 }

--- a/src/Editor/Util/EditorSettings.hpp
+++ b/src/Editor/Util/EditorSettings.hpp
@@ -20,6 +20,7 @@
  * Text Editor            | Path to text editor for scripts. | string | 
  * Grid Settings          | Whether to show grid settings.   | bool   | false
  * Grid Size              | Size of the grid.                | long   | 100
+ * Grid Line Width        | Width of the lines in the grid.  | long   | 3
  * Grid Snap              | Snap to grid when moving.        | bool   | false
  * Grid Snap Size         | Size to snap to.                 | long   | 100
  */


### PR DESCRIPTION
Adds an option for how thick the lines in the grid in the editor should be.

Fixes #492 