### PR TITLE
Fix copying resources to hymn folder when importing

### DIFF
--- a/src/Editor/GUI/Editors/SoundEditor.cpp
+++ b/src/Editor/GUI/Editors/SoundEditor.cpp
@@ -50,7 +50,7 @@ void SoundEditor::SetVisible(bool visible) {
 }
 
 void SoundEditor::FileSelected(const std::string& file) {
-    std::string destination = Hymn().GetPath() + FileSystem::DELIMITER + "Sounds" + FileSystem::DELIMITER + sound->name + ".ogg";
+    std::string destination = Hymn().GetPath() + "/" + sound->path + sound->name + ".ogg";
     FileSystem::Copy(file.c_str(), destination.c_str());
     Audio::SoundFile* soundFile = new Audio::VorbisFile(file.c_str());
     sound->Load(soundFile);

--- a/src/Editor/GUI/Editors/TextureEditor.cpp
+++ b/src/Editor/GUI/Editors/TextureEditor.cpp
@@ -58,7 +58,7 @@ void TextureEditor::SetVisible(bool visible) {
 }
 
 void TextureEditor::FileSelected(const std::string& file) {
-    std::string destination = Hymn().GetPath() + FileSystem::DELIMITER + "Textures" + FileSystem::DELIMITER + texture->name + ".png";
+    std::string destination = Hymn().GetPath() + "/" + texture->path + texture->name + ".png";
     FileSystem::Copy(file.c_str(), destination.c_str());
     texture->GetTexture()->Load(file.c_str(), texture->srgb);
 }

--- a/src/Video/Texture/Texture2D.cpp
+++ b/src/Video/Texture/Texture2D.cpp
@@ -39,8 +39,11 @@ void Texture2D::Load(const char* filename, bool srgb) {
     int components;
     unsigned char* data = stbi_load(filename, &width, &height, &components, 0);
     
-    if (data == NULL)
+    if (data == NULL) {
         Log() << "Couldn't load image " << filename << "\n";
+        loaded = false;
+        return;
+    }
     
     // Give the image to OpenGL.
     glTexImage2D(GL_TEXTURE_2D, 0, srgb ? GL_SRGB_ALPHA : GL_RGBA, width, height, 0, Format(components), GL_UNSIGNED_BYTE, data);


### PR DESCRIPTION
Resource copying still used the old paths (before adding subfolders for resources).

Fixes #491 