### PR TITLE
Fix crash due to non-existant shape for shape components.

### DIFF
--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -139,6 +139,9 @@ Component::Shape* PhysicsManager::CreateShape(Entity* owner) {
     auto comp = shapeComponents.Create();
     comp->entity = owner;
 
+    auto shape = std::shared_ptr<Physics::Shape>(new Physics::Shape(Physics::Shape::Sphere(1.0f)));
+    comp->SetShape(shape);
+
     auto rigidBodyComp = comp->entity->GetComponent<Component::RigidBody>();
     if (rigidBodyComp) {
         rigidBodyComp->GetBulletRigidBody()->setCollisionShape(comp->GetShape()->GetShape());


### PR DESCRIPTION
Fixes #519 

The crash happened because components are default created when calling `entity->AddComponent<type>();` in `EntityEditor`. Because of this, the shape component was in an invalid state (no actual shape) which returned a null struct in `RenderManager`. This is kind of a temporary solution, and could be more robustly handled with #407 (it knows what manager to create from, and also a suitable default) together with #236 (see comment about component constructor to force creation through managers).