### PR TITLE
Fix zero rigid body mass

### DIFF
--- a/src/Editor/GUI/Editors/EntityEditor.cpp
+++ b/src/Editor/GUI/Editors/EntityEditor.cpp
@@ -349,11 +349,18 @@ void EntityEditor::ListenerEditor(Component::Listener* listener) {
 }
 
 void EntityEditor::RigidBodyEditor(Component::RigidBody* rigidBody) {
-    ImGui::Indent();
-    if (ImGui::InputFloat("Mass", &rigidBodyMass)) {
-        Managers().physicsManager->SetMass(rigidBody, rigidBodyMass);
+    auto shapeComp = rigidBody->entity->GetComponent<Component::Shape>();
+    if (shapeComp) {
+        ImGui::Indent();
+        if (ImGui::InputFloat("Mass", &rigidBodyMass)) {
+            Managers().physicsManager->SetMass(rigidBody, rigidBodyMass);
+        }
+        ImGui::Unindent();
+    } else {
+        ImGui::Indent();
+        ImGui::TextWrapped("A rigid body is only valid with a complementary shape component. Please add one to allow editing this component.");
+        ImGui::Unindent();
     }
-    ImGui::Unindent();
 }
 
 void EntityEditor::ScriptEditor(Component::Script* script) {

--- a/src/Editor/GUI/Editors/EntityEditor.cpp
+++ b/src/Editor/GUI/Editors/EntityEditor.cpp
@@ -352,9 +352,8 @@ void EntityEditor::RigidBodyEditor(Component::RigidBody* rigidBody) {
     auto shapeComp = rigidBody->entity->GetComponent<Component::Shape>();
     if (shapeComp) {
         ImGui::Indent();
-        if (ImGui::InputFloat("Mass", &rigidBodyMass)) {
+        if (ImGui::InputFloat("Mass", &rigidBodyMass))
             Managers().physicsManager->SetMass(rigidBody, rigidBodyMass);
-        }
         ImGui::Unindent();
     } else {
         ImGui::Indent();

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -181,7 +181,10 @@ void PhysicsManager::SetShape(Component::Shape* comp, std::shared_ptr<::Physics:
 }
 
 void PhysicsManager::SetMass(Component::RigidBody* comp, float mass) {
-    comp->Mass(mass);
+    // Setting mass is only valid with a shape because it also sets inertia.
+    auto shapeComp = comp->entity->GetComponent<Component::Shape>();
+    if (shapeComp)
+        comp->Mass(mass);
 }
 
 const std::vector<Component::Shape*>& PhysicsManager::GetShapeComponents() const {


### PR DESCRIPTION
Fixes #526 

The problem was not only with 0 or negative mass, but any mass when no shape component was present. Setting mass also alters inertia, which requires the shape. Since no shape was ever set, a dereference of a null pointer followed. We assert for now that a rigid body without shape makes no sense, so attempting to set mass is silently ignored if no shape is present. To make things intuitive for level designers, you will be presented a helpful message in the editor and you won't even be able to set stuff on the rigid body until you have also added a shape component.

Still, setting negative mass makes no sense (or does it? :dancing_women:), so I'll open a bug to fix this too.