### PR TITLE
Link bullet statically

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,9 +40,6 @@
 [submodule "externals/Catch"]
 	path = externals/Catch
 	url = https://github.com/philsquared/Catch.git
-[submodule "externals/bullet3"]
-	path = externals/bullet3
-	url = https://github.com/bulletphysics/bullet3.git
 [submodule "externals/SteamAudio"]
 	path = externals/SteamAudio
 	url = https://github.com/Chainsawkitten/SteamAudio-CMake.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -52,4 +52,4 @@
 [submodule "externals/bullet3"]
 	path = externals/bullet3
 	url = https://github.com/Chainsawkitten/bullet3.git
-	branch = StaticLinking
+	branch = LargeGameProject

--- a/.gitmodules
+++ b/.gitmodules
@@ -49,3 +49,7 @@
 [submodule "externals/ImGuizmo"]
 	path = externals/ImGuizmo
 	url = https://github.com/CedricGuillemet/ImGuizmo.git
+[submodule "externals/bullet3"]
+	path = externals/bullet3
+	url = https://github.com/Chainsawkitten/bullet3.git
+	branch = StaticLinking

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ after_build:
         
         $env:BUILD_NAME = $BUILD_NAME
         
-        7z a -tzip $BUILD_NAME .\bin\Release\angelscript.dll .\bin\Release\assimp-vc140-mt.dll .\bin\Release\BulletCollision.dll .\bin\Release\BulletDynamics.dll .\bin\Release\BulletSoftBody.dll .\bin\Release\Editor.exe .\bin\Release\Engine.dll .\bin\Release\Game.exe .\bin\Release\glew32.dll .\bin\Release\glfw3.dll .\bin\Release\jsoncpp.dll .\bin\Release\LinearMath.dll .\bin\Release\OpenAL32.dll .\bin\Release\openvr_api64.dll .\bin\Release\phonon.dll .\bin\Release\portaudio_x64.dll .\bin\Release\Utility.dll .\bin\Release\Video.dll
+        7z a -tzip $BUILD_NAME .\bin\Release\angelscript.dll .\bin\Release\assimp-vc140-mt.dll .\bin\Release\Editor.exe .\bin\Release\Engine.dll .\bin\Release\Game.exe .\bin\Release\glew32.dll .\bin\Release\glfw3.dll .\bin\Release\jsoncpp.dll .\bin\Release\OpenAL32.dll .\bin\Release\openvr_api64.dll .\bin\Release\phonon.dll .\bin\Release\portaudio_x64.dll .\bin\Release\Utility.dll .\bin\Release\Video.dll
 
 artifacts:
   - path: $(BUILD_NAME)


### PR DESCRIPTION
Use forked bullet repository that always forces static linking. Bullet doesn't support dynamically linking the C++ API in MSVC.