### PR TITLE
Don't allow setting grid snap less than 1

### DIFF
--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -473,6 +473,8 @@ void Editor::ShowGridSettings() {
         EditorSettings::GetInstance().SetBool("Grid Snap", gridSettings.gridSnap);
         ImGui::DragInt("Snap Size", &gridSettings.snapOption, 1.0f, 1, 100);
         EditorSettings::GetInstance().SetLong("Grid Snap Size", gridSettings.snapOption);
+        if (gridSettings.snapOption < 1)
+            gridSettings.snapOption = 1;
         ImGui::End();
     }
 }


### PR DESCRIPTION
Fixes #517 
Fixes #512 