### PR TITLE
Ability to create trigger volume outside physics manager.

### DIFF
--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -31,6 +31,9 @@ PhysicsManager::PhysicsManager() {
 
     // Y axis up
     dynamicsWorld->setGravity(btVector3(0, -9.82, 0));
+
+    // Set the lockbox key we will use for lockboxes created in here.
+    triggerLockBoxKey.reset(new Util::LockBox<Physics::Trigger>::Key());
 }
 
 PhysicsManager::~PhysicsManager() {
@@ -74,36 +77,33 @@ void PhysicsManager::UpdateEntityTransforms() {
 }
 
 void PhysicsManager::OnTriggerEnter(Component::RigidBody* trigger, Component::RigidBody* object, std::function<void()> callback) {
-    auto t = MakeTrigger(trigger);
+    auto t = CreateTrigger(trigger);
     // Add the callback to the trigger observer
-    t->ForObserver(object->GetBulletRigidBody(), [&callback](::Physics::TriggerObserver& observer) {
-        observer.OnEnter(callback);
+    t.Open(triggerLockBoxKey, [object, &callback](Physics::Trigger& trigger) {
+        trigger.ForObserver(object->GetBulletRigidBody(), [&callback](Physics::TriggerObserver& observer) {
+            observer.OnEnter(callback);
+        });
     });
 }
 
 void PhysicsManager::OnTriggerRetain(Component::RigidBody* trigger, Component::RigidBody* object, std::function<void()> callback) {
-    auto t = MakeTrigger(trigger);
+    auto t = CreateTrigger(trigger);
     // Add the callback to the trigger observer
-    t->ForObserver(object->GetBulletRigidBody(), [&callback](::Physics::TriggerObserver& observer) {
-        observer.OnRetain(callback);
+    t.Open(triggerLockBoxKey, [object, &callback](Physics::Trigger& trigger) {
+        trigger.ForObserver(object->GetBulletRigidBody(), [&callback](::Physics::TriggerObserver& observer) {
+            observer.OnRetain(callback);
+        });
     });
 }
 
 void PhysicsManager::OnTriggerLeave(Component::RigidBody* trigger, Component::RigidBody* object, std::function<void()> callback) {
-    auto t = MakeTrigger(trigger);
+    auto t = CreateTrigger(trigger);
     // Add the callback to the trigger observer
-    t->ForObserver(object->GetBulletRigidBody(), [&callback](::Physics::TriggerObserver& observer) {
-        observer.OnLeave(callback);
+    t.Open(triggerLockBoxKey, [object, &callback](Physics::Trigger& trigger) {
+        trigger.ForObserver(object->GetBulletRigidBody(), [&callback](::Physics::TriggerObserver& observer) {
+            observer.OnLeave(callback);
+        });
     });
-}
-
-Physics::Trigger* PhysicsManager::MakeTrigger(Component::RigidBody* comp) {
-    btTransform trans(btQuaternion(0, 0, 0, 1), ::Physics::glmToBt(comp->entity->position));
-    Physics::Trigger* trigger = new Physics::Trigger(trans);
-    auto shapeComp = comp->entity->GetComponent<Component::Shape>();
-    trigger->SetCollisionShape(shapeComp ? shapeComp->GetShape() : nullptr);
-    triggers.push_back(trigger);
-    return trigger;
 }
 
 Component::RigidBody* PhysicsManager::CreateRigidBody(Entity* owner) {
@@ -174,6 +174,15 @@ Component::Shape* PhysicsManager::CreateShape(Entity* owner, const Json::Value& 
     }
 
     return comp;
+}
+
+Util::LockBox<Physics::Trigger> PhysicsManager::CreateTrigger(Component::RigidBody* comp) {
+    btTransform trans(btQuaternion(0, 0, 0, 1), ::Physics::glmToBt(comp->entity->position));
+    Physics::Trigger* trigger = new Physics::Trigger(trans);
+    auto shapeComp = comp->entity->GetComponent<Component::Shape>();
+    trigger->SetCollisionShape(shapeComp ? shapeComp->GetShape() : nullptr);
+    triggers.push_back(trigger);
+    return Util::LockBox<Physics::Trigger>(triggerLockBoxKey, trigger);
 }
 
 void PhysicsManager::SetShape(Component::Shape* comp, std::shared_ptr<::Physics::Shape> shape) {

--- a/src/Engine/Manager/PhysicsManager.hpp
+++ b/src/Engine/Manager/PhysicsManager.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <glm/glm.hpp>
 #include <memory>
+#include <Utility/LockBox.hpp>
 #include <vector>
 #include "../Entity/ComponentContainer.hpp"
 #include "../linking.hpp"
@@ -98,6 +99,15 @@ class PhysicsManager {
          */
         ENGINE_API Component::Shape* CreateShape(Entity* owner, const Json::Value& node);
 
+        /// Create a trigger volume that can be used to check intersection
+        /// events against physics bodies.
+        /**
+         * @param comp Rigid body that represents the volume. This is intended
+         * to be changed to a pure shape in the future.
+         * @return A reference to the internal trigger.
+         */
+        ENGINE_API Util::LockBox<Physics::Trigger> CreateTrigger(Component::RigidBody* comp);
+
         /// Set the shape of a given Component::Shape component.
         /**
          * @param comp The component on which to set the shape.
@@ -127,8 +137,6 @@ class PhysicsManager {
         PhysicsManager(PhysicsManager const&) = delete;
         void operator=(PhysicsManager const&) = delete;
 
-        ::Physics::Trigger* MakeTrigger(Component::RigidBody* comp);
-
         glm::vec3 gravity = glm::vec3(0.f, -9.82f, 0.f);
 
         ComponentContainer<Component::RigidBody> rigidBodyComponents;
@@ -140,5 +148,6 @@ class PhysicsManager {
         btSequentialImpulseConstraintSolver* solver = nullptr;
         btDiscreteDynamicsWorld* dynamicsWorld = nullptr;
 
+        std::shared_ptr<Util::LockBox<Physics::Trigger>::Key> triggerLockBoxKey;
         std::vector<::Physics::Trigger*> triggers;
 };


### PR DESCRIPTION
You are then given a reference intended to be passed back to `PhysicsManager` for manipulation.

Resolves #580 