### PR TITLE
Setup trigger volume listeners in repeat trigger

### DIFF
--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -85,6 +85,14 @@ void PhysicsManager::OnTriggerEnter(Utility::LockBox<Physics::Trigger> trigger, 
     });
 }
 
+void PhysicsManager::ForgetTriggerEnter(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object) {
+    trigger.Open(triggerLockBoxKey, [object](Physics::Trigger& trigger) {
+        trigger.ForObserver(object->GetBulletRigidBody(), [](Physics::TriggerObserver& observer) {
+            observer.ForgetEnter();
+        });
+    });
+}
+
 void PhysicsManager::OnTriggerRetain(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object, std::function<void()> callback) {
     // Add the callback to the trigger observer
     trigger.Open(triggerLockBoxKey, [object, &callback](Physics::Trigger& trigger) {
@@ -94,11 +102,27 @@ void PhysicsManager::OnTriggerRetain(Utility::LockBox<Physics::Trigger> trigger,
     });
 }
 
+void PhysicsManager::ForgetTriggerRetain(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object) {
+    trigger.Open(triggerLockBoxKey, [object](Physics::Trigger& trigger) {
+        trigger.ForObserver(object->GetBulletRigidBody(), [](Physics::TriggerObserver& observer) {
+            observer.ForgetRetain();
+        });
+    });
+}
+
 void PhysicsManager::OnTriggerLeave(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object, std::function<void()> callback) {
     // Add the callback to the trigger observer
     trigger.Open(triggerLockBoxKey, [object, &callback](Physics::Trigger& trigger) {
         trigger.ForObserver(object->GetBulletRigidBody(), [&callback](::Physics::TriggerObserver& observer) {
             observer.OnLeave(callback);
+        });
+    });
+}
+
+void PhysicsManager::ForgetTriggerLeave(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object) {
+    trigger.Open(triggerLockBoxKey, [object](Physics::Trigger& trigger) {
+        trigger.ForObserver(object->GetBulletRigidBody(), [](Physics::TriggerObserver& observer) {
+            observer.ForgetLeave();
         });
     });
 }

--- a/src/Engine/Manager/PhysicsManager.hpp
+++ b/src/Engine/Manager/PhysicsManager.hpp
@@ -53,6 +53,13 @@ class PhysicsManager {
          */
         ENGINE_API void OnTriggerEnter(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object, std::function<void()> callback);
 
+        /// Stop listening for when |object| has entered |trigger|.
+        /**
+         * @param trigger What trigger to stop listening on.
+         * @param object Body that is to be forgotten.
+         */
+        ENGINE_API void ForgetTriggerEnter(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object);
+
         /// Set up listener for when |object| is intersecting |trigger|.
         /**
          * @param trigger What trigger to check against.
@@ -61,6 +68,13 @@ class PhysicsManager {
          */
         ENGINE_API void OnTriggerRetain(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object, std::function<void()> callback);
 
+        /// Stop listening for when |object| is intersecting |trigger|.
+        /**
+         * @param trigger What trigger to stop listening on.
+         * @param object Body that is to be forgotten.
+         */
+        ENGINE_API void ForgetTriggerRetain(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object);
+
         /// Set up listener for when |object| has left |trigger|.
         /**
          * @param trigger What trigger to check against.
@@ -68,6 +82,13 @@ class PhysicsManager {
          * @param callback Function to call when resolving event.
          */
         ENGINE_API void OnTriggerLeave(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object, std::function<void()> callback);
+
+        /// Stop listening for when |object| has left |trigger|.
+        /**
+         * @param trigger What trigger to stop listening on.
+         * @param object Body that is to be forgotten.
+         */
+        ENGINE_API void ForgetTriggerLeave(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object);
 
         /// Create rigid body component.
         /**

--- a/src/Engine/Physics/TriggerObserver.cpp
+++ b/src/Engine/Physics/TriggerObserver.cpp
@@ -90,12 +90,24 @@ namespace Physics {
         enterHandler = handler;
     }
 
+    void TriggerObserver::ForgetEnter() {
+        enterHandler = nullptr;
+    }
+
     void TriggerObserver::OnRetain(const std::function<void()>& handler) {
         retainHandler = handler;
     }
 
+    void TriggerObserver::ForgetRetain() {
+        retainHandler = nullptr;
+    }
+
     void TriggerObserver::OnLeave(const std::function<void()>& handler) {
         leaveHandler = handler;
+    }
+
+    void TriggerObserver::ForgetLeave() {
+        leaveHandler = nullptr;
     }
 
     // Called with each contact for our own processing. This is where we can

--- a/src/Engine/Physics/TriggerObserver.hpp
+++ b/src/Engine/Physics/TriggerObserver.hpp
@@ -59,6 +59,10 @@ namespace Physics {
              */
             ENGINE_API void OnEnter(const std::function<void()>& handler);
 
+            /// Remove handler for when the observer begins intersecting its
+            /// associated trigger volume.
+            ENGINE_API void ForgetEnter();
+
             /// Set up a handler for when the observer continues intersecting
             /// its associated trigger volume.
             /**
@@ -66,12 +70,20 @@ namespace Physics {
              */
             ENGINE_API void OnRetain(const std::function<void()>& handler);
 
+            /// Remove handler for when the observer continues intersecting
+            /// its associated trigger volume.
+            ENGINE_API void ForgetRetain();
+
             /// Set up a handler for when the observer stops intersecting its
             /// associated trigger volume.
             /**
              * @param handler Handler function to call.
              */
             ENGINE_API void OnLeave(const std::function<void()>& handler);
+
+            /// Remove handler for when the observer stops intersecting its
+            /// associated trigger volume.
+            ENGINE_API void ForgetLeave();
 
         private:
             /// Overridden from btCollisionWorld::ContactResultCallback for

--- a/src/Engine/Trigger/TriggerRepeat.cpp
+++ b/src/Engine/Trigger/TriggerRepeat.cpp
@@ -1,5 +1,9 @@
 #include "TriggerRepeat.hpp"
 
+#include "../Component/RigidBody.hpp"
+#include "../Entity/Entity.hpp"
+#include "../Manager/Managers.hpp"
+#include "../Manager/PhysicsManager.hpp"
 
 TriggerRepeat::TriggerRepeat() {
 
@@ -10,16 +14,33 @@ TriggerRepeat::~TriggerRepeat() {
 }
 
 void TriggerRepeat::OnEnter() {
-    // TODO
+    if (collidedEntity && collidedEntity->GetComponent<Component::RigidBody>()) {
+        Component::RigidBody* rigidBodyComp = collidedEntity->GetComponent<Component::RigidBody>();
+        Managers().physicsManager->ForgetTriggerEnter(triggerVolume, rigidBodyComp);
+        Managers().physicsManager->ForgetTriggerRetain(triggerVolume, rigidBodyComp);
+        Managers().physicsManager->ForgetTriggerLeave(triggerVolume, rigidBodyComp);
+        Managers().physicsManager->OnTriggerEnter(triggerVolume, rigidBodyComp, std::bind(&TriggerRepeat::HandleTriggerEvent, this));
+    }
+}
+
+void TriggerRepeat::OnRetain() {
+    if (collidedEntity && collidedEntity->GetComponent<Component::RigidBody>()) {
+        Component::RigidBody* rigidBodyComp = collidedEntity->GetComponent<Component::RigidBody>();
+        Managers().physicsManager->ForgetTriggerEnter(triggerVolume, rigidBodyComp);
+        Managers().physicsManager->ForgetTriggerRetain(triggerVolume, rigidBodyComp);
+        Managers().physicsManager->ForgetTriggerLeave(triggerVolume, rigidBodyComp);
+        Managers().physicsManager->OnTriggerRetain(triggerVolume, rigidBodyComp, std::bind(&TriggerRepeat::HandleTriggerEvent, this));
+    }
 }
 
 void TriggerRepeat::OnLeave() {
-    // TODO
-}
-
-
-void TriggerRepeat::OnRemain() {
-    // TODO
+    if (collidedEntity && collidedEntity->GetComponent<Component::RigidBody>()) {
+        Component::RigidBody* rigidBodyComp = collidedEntity->GetComponent<Component::RigidBody>();
+        Managers().physicsManager->ForgetTriggerEnter(triggerVolume, rigidBodyComp);
+        Managers().physicsManager->ForgetTriggerRetain(triggerVolume, rigidBodyComp);
+        Managers().physicsManager->ForgetTriggerLeave(triggerVolume, rigidBodyComp);
+        Managers().physicsManager->OnTriggerLeave(triggerVolume, rigidBodyComp, std::bind(&TriggerRepeat::HandleTriggerEvent, this));
+    }
 }
 
 std::string TriggerRepeat::GetName() {
@@ -84,4 +105,8 @@ Entity* TriggerRepeat::GetCollidedEntity() {
 
 void TriggerRepeat::SetCollidedEntity(Entity* value) {
     collidedEntity = value;
+}
+
+void TriggerRepeat::HandleTriggerEvent() {
+    triggered = true;
 }

--- a/src/Engine/Trigger/TriggerRepeat.hpp
+++ b/src/Engine/Trigger/TriggerRepeat.hpp
@@ -20,9 +20,17 @@ class TriggerRepeat : public SuperTrigger {
         ENGINE_API TriggerRepeat();
         ENGINE_API ~TriggerRepeat();
 
+        /// Setup the trigger to listen for `enter` events on the trigger
+        /// volume, forgetting any previously set listener
         ENGINE_API void OnEnter();
+
+        /// Setup the trigger to listen for `retain` events on the trigger
+        /// volume, forgetting any previously set listener
+        ENGINE_API void OnRetain();
+
+        /// Setup the trigger to listen for `leave` events on the trigger
+        /// volume, forgetting any previously set listener
         ENGINE_API void OnLeave();
-        ENGINE_API void OnRemain();
 
         ENGINE_API std::string GetName();
         ENGINE_API void SetName(std::string value);
@@ -49,6 +57,8 @@ class TriggerRepeat : public SuperTrigger {
         ENGINE_API void SetCollidedEntity(Entity* value);
 
     private:
+        void HandleTriggerEvent();
+
         std::string name = "DEBUG";
         std::string targetFunction = "DEBUG";
         bool startActive = false;
@@ -58,4 +68,5 @@ class TriggerRepeat : public SuperTrigger {
         Entity* targetEntity = nullptr;
         Entity* collidedEntity = nullptr;
         Utility::LockBox<Physics::Trigger> triggerVolume;
+        bool triggered = false;
 };


### PR DESCRIPTION
Resolves #583 
There were already skeletons for setting listener directly on a `TriggerRepeat` so I made the implementation there. It seems the intention for trigger repeat is to only keep a single listener at a time, which is why others are forgotten before setting the new one.