### PR TITLE
Initialize member variables

### DIFF
--- a/src/Engine/Audio/SteamAudio.cpp
+++ b/src/Engine/Audio/SteamAudio.cpp
@@ -6,7 +6,8 @@ SteamAudio::SteamAudio() {
 }
 
 SteamAudio::SteamAudio(IPLContext * context, IPLhandle * environment) {
-
+    this->context = context;
+    this->environmentalRenderer = environment;
 }
 
 SteamAudio::~SteamAudio() {

--- a/src/Engine/Component/Mesh.hpp
+++ b/src/Engine/Component/Mesh.hpp
@@ -44,7 +44,6 @@ namespace Component {
             ENGINE_API void SetSelected(bool value);
 
     private:        
-        bool isSelected;
-
+        bool isSelected = false;
     };
 }

--- a/src/Engine/Manager/ResourceManager.hpp
+++ b/src/Engine/Manager/ResourceManager.hpp
@@ -126,11 +126,11 @@ class ResourceManager {
         void operator=(ResourceManager const&) = delete;
         
         // Rectangle
-        Video::Geometry::Rectangle* rectangle;
+        Video::Geometry::Rectangle* rectangle = nullptr;
         int rectangleCount = 0;
         
         // Cube
-        Geometry::Cube* cube;
+        Geometry::Cube* cube = nullptr;
         int cubeCount = 0;
         
         // Model


### PR DESCRIPTION
Solves Sonar bugs "Member variable x is not initialized in the constructor."