### PR TITLE
Debug drawing oriented cuboid

### DIFF
--- a/src/Engine/Manager/DebugDrawingManager.cpp
+++ b/src/Engine/Manager/DebugDrawingManager.cpp
@@ -40,10 +40,10 @@ void DebugDrawingManager::AddLine(const glm::vec3& startPosition, const glm::vec
     lines.push_back(line);
 }
 
-void DebugDrawingManager::AddCuboid(const glm::vec3& minCoordinates, const glm::vec3& maxCoordinates, const glm::vec3& color, float lineWidth, float duration, bool depthTesting) {
+void DebugDrawingManager::AddCuboid(const glm::vec3& dimensions, const glm::mat4& matrix, const glm::vec3& color, float lineWidth, float duration, bool depthTesting) {
     DebugDrawing::Cuboid cuboid;
-    cuboid.minCoordinates = minCoordinates;
-    cuboid.maxCoordinates = maxCoordinates;
+    cuboid.dimensions = dimensions;
+    cuboid.matrix = matrix;
     cuboid.color = color;
     cuboid.lineWidth = lineWidth;
     cuboid.duration = duration;

--- a/src/Engine/Manager/DebugDrawingManager.hpp
+++ b/src/Engine/Manager/DebugDrawingManager.hpp
@@ -39,14 +39,14 @@ class DebugDrawingManager {
         
         /// Add a cuboid to the world.
         /**
-         * @param minCoordinates The minimum coordinates of the box.
-         * @param maxCoordinates The maximum coordinates of the box.
+         * @param dimensions The dimensions of the cuboid.
+         * @param matrix Matrix used to transform the cuboid.
          * @param color Color of the lines.
          * @param lineWidth The width of the lines used to draw the box.
          * @param duration How long the box should stay in the world (in seconds).
          * @param depthTesting Whether to enable depth testing.
          */
-        ENGINE_API void AddCuboid(const glm::vec3& minCoordinates, const glm::vec3& maxCoordinates, const glm::vec3& color, float lineWidth = 1.f, float duration = 0.f, bool depthTesting = true);
+        ENGINE_API void AddCuboid(const glm::vec3& dimensions, const glm::mat4& matrix, const glm::vec3& color, float lineWidth = 1.f, float duration = 0.f, bool depthTesting = true);
         
         /// Add a plane to the world.
         /**

--- a/src/Engine/Manager/RenderManager.cpp
+++ b/src/Engine/Manager/RenderManager.cpp
@@ -409,7 +409,10 @@ void RenderManager::RenderEditorEntities(World& world, bool soundSources, bool p
                 Managers().debugDrawingManager->AddPlane(shapeComp->entity->position, shape.GetPlaneData()->normal, glm::vec2(1.0f, 1.0f), glm::vec3(1.0f, 1.0f, 1.0f));
             } else if (shape.GetKind() == ::Physics::Shape::Kind::Box) {
                 glm::vec3 dimensions(shape.GetBoxData()->width, shape.GetBoxData()->height, shape.GetBoxData()->depth);
-                Managers().debugDrawingManager->AddCuboid(dimensions, shapeComp->entity->GetModelMatrix(), glm::vec3(1.0f, 1.0f, 1.0f));
+                glm::vec3 position = shapeComp->entity->GetWorldPosition();
+                glm::quat orientation = shapeComp->entity->GetWorldOrientation();
+                glm::mat4 transformationMatrix = glm::translate(glm::toMat4(orientation), position);
+                Managers().debugDrawingManager->AddCuboid(dimensions, transformationMatrix, glm::vec3(1.0f, 1.0f, 1.0f));
             }
         }
     }

--- a/src/Engine/Manager/RenderManager.cpp
+++ b/src/Engine/Manager/RenderManager.cpp
@@ -345,6 +345,9 @@ void RenderManager::RenderEditorEntities(World& world, bool soundSources, bool p
             }
             else if (shape.GetKind() == ::Physics::Shape::Kind::Plane) {
                 Managers().debugDrawingManager->AddPlane(shapeComp->entity->position, shape.GetPlaneData()->normal, glm::vec2(1.0f, 1.0f), glm::vec3(1.0f, 1.0f, 1.0f));
+            } else if (shape.GetKind() == ::Physics::Shape::Kind::Box) {
+                glm::vec3 dimensions(shape.GetBoxData()->width, shape.GetBoxData()->height, shape.GetBoxData()->depth);
+                Managers().debugDrawingManager->AddCuboid(dimensions, shapeComp->entity->GetModelMatrix(), glm::vec3(1.0f, 1.0f, 1.0f));
             }
         }
     }

--- a/src/Engine/Manager/ScriptManager.cpp
+++ b/src/Engine/Manager/ScriptManager.cpp
@@ -407,7 +407,7 @@ ScriptManager::ScriptManager() {
     engine->RegisterObjectType("DebugDrawingManager", 0, asOBJ_REF | asOBJ_NOCOUNT);
     engine->RegisterObjectMethod("DebugDrawingManager", "void AddPoint(const vec3 &in, const vec3 &in, float, float = 0.0, bool = true)", asMETHOD(DebugDrawingManager, AddPoint), asCALL_THISCALL);
     engine->RegisterObjectMethod("DebugDrawingManager", "void AddLine(const vec3 &in, const vec3 &in, const vec3 &in, float = 1.0, float = 0.0, bool = true)", asMETHOD(DebugDrawingManager, AddLine), asCALL_THISCALL);
-    engine->RegisterObjectMethod("DebugDrawingManager", "void AddCuboid(const vec3 &in, const vec3 &in, const vec3 &in, float = 1.0, float = 0.0, bool = true)", asMETHOD(DebugDrawingManager, AddCuboid), asCALL_THISCALL);
+    engine->RegisterObjectMethod("DebugDrawingManager", "void AddCuboid(const vec3 &in, const mat4 &in, const vec3 &in, float = 1.0, float = 0.0, bool = true)", asMETHOD(DebugDrawingManager, AddCuboid), asCALL_THISCALL);
     engine->RegisterObjectMethod("DebugDrawingManager", "void AddPlane(const vec3 &in, const vec3 &in, const vec2 &in, const vec3 &in, float = 1.0, float = 0.0, bool = true)", asMETHOD(DebugDrawingManager, AddPlane), asCALL_THISCALL);
     engine->RegisterObjectMethod("DebugDrawingManager", "void AddCircle(const vec3 &in, const vec3 &in, float, const vec3 &in, float = 1.0, float = 0.0, bool = true)", asMETHOD(DebugDrawingManager, AddCircle), asCALL_THISCALL);
     engine->RegisterObjectMethod("DebugDrawingManager", "void AddSphere(const vec3 &in, float, const vec3 &in, float = 1.0, float = 0.0, bool = true)", asMETHOD(DebugDrawingManager, AddSphere), asCALL_THISCALL);

--- a/src/Video/DebugDrawing.cpp
+++ b/src/Video/DebugDrawing.cpp
@@ -33,30 +33,30 @@ DebugDrawing::DebugDrawing() {
     
     // Create cuboid vertex array.
     glm::vec3 box[24];
-    box[0] = glm::vec3(0.f, 0.f, 0.f);
-    box[1] = glm::vec3(1.f, 0.f, 0.f);
-    box[2] = glm::vec3(1.f, 0.f, 0.f);
-    box[3] = glm::vec3(1.f, 1.f, 0.f);
-    box[4] = glm::vec3(1.f, 1.f, 0.f);
-    box[5] = glm::vec3(0.f, 1.f, 0.f);
-    box[6] = glm::vec3(1.f, 1.f, 0.f);
-    box[7] = glm::vec3(1.f, 1.f, 1.f);
-    box[8] = glm::vec3(1.f, 1.f, 1.f);
-    box[9] = glm::vec3(1.f, 0.f, 1.f);
-    box[10] = glm::vec3(1.f, 0.f, 1.f);
-    box[11] = glm::vec3(1.f, 0.f, 0.f);
-    box[12] = glm::vec3(0.f, 1.f, 0.f);
-    box[13] = glm::vec3(0.f, 1.f, 1.f);
-    box[14] = glm::vec3(0.f, 1.f, 1.f);
-    box[15] = glm::vec3(0.f, 0.f, 1.f);
-    box[16] = glm::vec3(0.f, 1.f, 0.f);
-    box[17] = glm::vec3(0.f, 0.f, 0.f);
-    box[18] = glm::vec3(0.f, 0.f, 1.f);
-    box[19] = glm::vec3(0.f, 0.f, 0.f);
-    box[20] = glm::vec3(0.f, 1.f, 1.f);
-    box[21] = glm::vec3(1.f, 1.f, 1.f);
-    box[22] = glm::vec3(0.f, 0.f, 1.f);
-    box[23] = glm::vec3(1.f, 0.f, 1.f);
+    box[0] = glm::vec3(-0.5f, -0.5f, -0.5f);
+    box[1] = glm::vec3(0.5f, -0.5f, -0.5f);
+    box[2] = glm::vec3(0.5f, -0.5f, -0.5f);
+    box[3] = glm::vec3(0.5f, 0.5f, -0.5f);
+    box[4] = glm::vec3(0.5f, 0.5f, -0.5f);
+    box[5] = glm::vec3(-0.5f, 0.5f, -0.5f);
+    box[6] = glm::vec3(0.5f, 0.5f, -0.5f);
+    box[7] = glm::vec3(0.5f, 0.5f, 0.5f);
+    box[8] = glm::vec3(0.5f, 0.5f, 0.5f);
+    box[9] = glm::vec3(0.5f, -0.5f, 0.5f);
+    box[10] = glm::vec3(0.5f, -0.5f, 0.5f);
+    box[11] = glm::vec3(0.5f, -0.5f, -0.5f);
+    box[12] = glm::vec3(-0.5f, 0.5f, -0.5f);
+    box[13] = glm::vec3(-0.5f, 0.5f, 0.5f);
+    box[14] = glm::vec3(-0.5f, 0.5f, 0.5f);
+    box[15] = glm::vec3(-0.5f, -0.5f, 0.5f);
+    box[16] = glm::vec3(-0.5f, 0.5f, -0.5f);
+    box[17] = glm::vec3(-0.5f, 0.5f, -0.5f);
+    box[18] = glm::vec3(-0.5f, 0.5f, 0.5f);
+    box[19] = glm::vec3(-0.5f, -0.5f, -0.5f);
+    box[20] = glm::vec3(-0.5f, 0.5f, 0.5f);
+    box[21] = glm::vec3(0.5f, 0.5f, 0.5f);
+    box[22] = glm::vec3(-0.5f, -0.5f, 0.5f);
+    box[23] = glm::vec3(0.5f, -0.5f, 0.5f);
     
     CreateVertexArray(box, 24, cuboidVertexBuffer, cuboidVertexArray);
     

--- a/src/Video/DebugDrawing.cpp
+++ b/src/Video/DebugDrawing.cpp
@@ -50,8 +50,8 @@ DebugDrawing::DebugDrawing() {
     box[14] = glm::vec3(-0.5f, 0.5f, 0.5f);
     box[15] = glm::vec3(-0.5f, -0.5f, 0.5f);
     box[16] = glm::vec3(-0.5f, 0.5f, -0.5f);
-    box[17] = glm::vec3(-0.5f, 0.5f, -0.5f);
-    box[18] = glm::vec3(-0.5f, 0.5f, 0.5f);
+    box[17] = glm::vec3(-0.5f, -0.5f, -0.5f);
+    box[18] = glm::vec3(-0.5f, -0.5f, 0.5f);
     box[19] = glm::vec3(-0.5f, -0.5f, -0.5f);
     box[20] = glm::vec3(-0.5f, 0.5f, 0.5f);
     box[21] = glm::vec3(0.5f, 0.5f, 0.5f);

--- a/src/Video/DebugDrawing.cpp
+++ b/src/Video/DebugDrawing.cpp
@@ -140,7 +140,7 @@ void DebugDrawing::DrawLine(const Line& line) {
 void DebugDrawing::DrawCuboid(const Cuboid& cuboid) {
     BindVertexArray(cuboidVertexArray);
     
-    glm::mat4 model(glm::translate(glm::mat4(), cuboid.minCoordinates) * glm::scale(glm::mat4(), cuboid.maxCoordinates - cuboid.minCoordinates));
+    glm::mat4 model(cuboid.matrix * glm::scale(glm::mat4(), cuboid.dimensions));
     
     glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &model[0][0]);
     cuboid.depthTesting ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);

--- a/src/Video/DebugDrawing.hpp
+++ b/src/Video/DebugDrawing.hpp
@@ -51,11 +51,11 @@ namespace Video {
             
             /// A debug drawing cuboid.
             struct Cuboid {
-                /// The minimum coordinates of the box.
-                glm::vec3 minCoordinates;
+                /// The dimensions of the cuboids.
+                glm::vec3 dimensions;
                 
-                /// The maximum coordinates of the box.
-                glm::vec3 maxCoordinates;
+                /// The matrix used to transform the cuboid.
+                glm::mat4 matrix;
                 
                 /// Color.
                 glm::vec3 color;


### PR DESCRIPTION
Change debug drawing cuboid so it accepts a transformation matrix. Render physics boxes in editor.

Fixes #725 