### PR TITLE
Fix crash after changing shape

### DIFF
--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -214,6 +214,10 @@ Utility::LockBox<Physics::Trigger> PhysicsManager::CreateTrigger(Component::Rigi
 
 void PhysicsManager::SetShape(Component::Shape* comp, std::shared_ptr<::Physics::Shape> shape) {
     comp->SetShape(shape);
+
+    auto rigidBodyComp = comp->entity->GetComponent<Component::RigidBody>();
+    if (rigidBodyComp)
+        rigidBodyComp->GetBulletRigidBody()->setCollisionShape(comp->GetShape()->GetShape());
 }
 
 float PhysicsManager::GetMass(Component::RigidBody* comp) {


### PR DESCRIPTION
Changing shape in the editor while having a rigid body present never updated Bullet pointers internally, thus causing a crash when loading the game.