### PR TITLE
Kinematic object support

### DIFF
--- a/src/Editor/GUI/Editors/RigidBodyEditor.cpp
+++ b/src/Editor/GUI/Editors/RigidBodyEditor.cpp
@@ -14,8 +14,18 @@ namespace GUI {
         auto shapeComp = comp->entity->GetComponent<Component::Shape>();
         if (shapeComp) {
             ImGui::Indent();
+
             if (ImGui::InputFloat("Mass", &mass))
                 Managers().physicsManager->SetMass(comp, mass);
+
+            bool kinematic = comp->IsKinematic();
+            if (ImGui::Checkbox("Kinematic", &kinematic)) {
+                if (kinematic)
+                    Managers().physicsManager->MakeKinematic(comp);
+                else
+                    Managers().physicsManager->MakeDynamic(comp);
+            }
+
             ImGui::Unindent();
         }
         else {

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -45,14 +45,26 @@ namespace Component {
     }
 
     glm::vec3 RigidBody::GetPosition() const {
-        btTransform trans = rigidBody->getWorldTransform();
+        btTransform trans;
+        if (IsKinematic())
+            rigidBody->getMotionState()->getWorldTransform(trans);
+        else
+            trans = rigidBody->getWorldTransform();
+
         return Physics::btToGlm(trans.getOrigin());
     }
 
     void RigidBody::SetPosition(const glm::vec3& pos) {
-        btTransform trans = rigidBody->getWorldTransform();
-        trans.setOrigin(Physics::glmToBt(pos));
-        rigidBody->setWorldTransform(trans);
+        if (IsKinematic()) {
+            btTransform trans;
+            rigidBody->getMotionState()->getWorldTransform(trans);
+            trans.setOrigin(Physics::glmToBt(pos));
+            rigidBody->getMotionState()->setWorldTransform(trans);
+        } else {
+            btTransform trans = rigidBody->getWorldTransform();
+            trans.setOrigin(Physics::glmToBt(pos));
+            rigidBody->setWorldTransform(trans);
+        }
     }
 
     glm::quat RigidBody::GetOrientation() const {

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -13,6 +13,10 @@ namespace Component {
         return component;
     }
 
+    bool RigidBody::IsKinematic() const {
+        return kinematic;
+    }
+
     btRigidBody* RigidBody::GetBulletRigidBody() {
         return rigidBody;
     }
@@ -72,5 +76,15 @@ namespace Component {
         rigidBody->getCollisionShape()->calculateLocalInertia(mass, inertia);
         rigidBody->setMassProps(mass, inertia);
         this->mass = mass;
+    }
+
+    void RigidBody::MakeKinematic() {
+        rigidBody->setCollisionFlags(rigidBody->getCollisionFlags() | btCollisionObject::CF_KINEMATIC_OBJECT);
+        kinematic = true;
+    }
+
+    void RigidBody::MakeDynamic() {
+        rigidBody->setCollisionFlags(rigidBody->getCollisionFlags() & ~btCollisionObject::CF_KINEMATIC_OBJECT);
+        kinematic = false;
     }
 }

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -112,4 +112,12 @@ namespace Component {
         rigidBody->setCollisionFlags(rigidBody->getCollisionFlags() & ~btCollisionObject::CF_KINEMATIC_OBJECT);
         kinematic = false;
     }
+
+    bool RigidBody::GetForceTransformSync() const {
+        return forceTransformSync;
+    }
+
+    void RigidBody::SetForceTransformSync(bool sync) {
+        forceTransformSync = sync;
+    }
 }

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -68,14 +68,26 @@ namespace Component {
     }
 
     glm::quat RigidBody::GetOrientation() const {
-        btTransform trans = rigidBody->getWorldTransform();
+        btTransform trans;
+        if (IsKinematic())
+            rigidBody->getMotionState()->getWorldTransform(trans);
+        else
+            trans = rigidBody->getWorldTransform();
+
         return Physics::btToGlm(trans.getRotation());
     }
 
     void RigidBody::SetOrientation(const glm::quat& rotation) {
-        btTransform trans = rigidBody->getWorldTransform();
-        trans.setRotation(Physics::glmToBt(rotation));
-        rigidBody->setWorldTransform(trans);
+        if (IsKinematic()) {
+            btTransform trans;
+            rigidBody->getMotionState()->getWorldTransform(trans);
+            trans.setRotation(Physics::glmToBt(rotation));
+            rigidBody->getMotionState()->setWorldTransform(trans);
+        } else {
+            btTransform trans = rigidBody->getWorldTransform();
+            trans.setRotation(Physics::glmToBt(rotation));
+            rigidBody->setWorldTransform(trans);
+        }
     }
 
     float RigidBody::GetMass() {

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -10,6 +10,7 @@ namespace Component {
     Json::Value RigidBody::Save() const {
         Json::Value component;
         component["mass"] = mass;
+        component["kinematic"] = kinematic;
         return component;
     }
 

--- a/src/Engine/Component/RigidBody.hpp
+++ b/src/Engine/Component/RigidBody.hpp
@@ -30,6 +30,14 @@ namespace Component {
              */
             ENGINE_API Json::Value Save() const override;
 
+            /// Return a value indicating whether the rigid body is kinematic
+            /// or dynamic. In the former case the transform is determined by
+            /// that of its entity. In the latter case, Bullet calculates it.
+            /**
+             * @return True if kinematic, false if dynamic.
+             */
+            ENGINE_API bool IsKinematic() const;
+
         private:
             // Get the underlying Bullet rigid body. If none has been set,
             // nullptr is returned.
@@ -60,7 +68,11 @@ namespace Component {
             // Set the mass in kilograms of a rigid body.
             void SetMass(float mass);
 
+            void MakeKinematic();
+            void MakeDynamic();
+
             float mass = 1.0f;
             btRigidBody* rigidBody = nullptr;
+            bool kinematic = false;
     };
 }

--- a/src/Engine/Component/RigidBody.hpp
+++ b/src/Engine/Component/RigidBody.hpp
@@ -71,8 +71,14 @@ namespace Component {
             void MakeKinematic();
             void MakeDynamic();
 
+            // Get/set whether a dynamic rigid body should synchronize its
+            // transform against the owning entity during the next simulation.
+            bool GetForceTransformSync() const;
+            void SetForceTransformSync(bool sync);
+
             float mass = 1.0f;
             btRigidBody* rigidBody = nullptr;
             bool kinematic = false;
+            bool forceTransformSync = true; // For first frame
     };
 }

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -53,11 +53,19 @@ void PhysicsManager::Update(float deltaTime) {
             continue;
         }
 
-        dynamicsWorld->removeRigidBody(rigidBodyComp->GetBulletRigidBody());
-        rigidBodyComp->SetPosition(rigidBodyComp->entity->GetWorldPosition());
-        rigidBodyComp->SetOrientation(rigidBodyComp->entity->GetWorldOrientation());
-        rigidBodyComp->SetMass(rigidBodyComp->GetMass());
-        dynamicsWorld->addRigidBody(rigidBodyComp->GetBulletRigidBody());
+        auto worldPos = rigidBodyComp->entity->GetWorldPosition();
+        auto worldOrientation = rigidBodyComp->entity->GetWorldOrientation();
+        if (rigidBodyComp->IsKinematic()) {
+            rigidBodyComp->SetPosition(worldPos);
+            rigidBodyComp->SetOrientation(worldOrientation);
+        } else if (rigidBodyComp->GetForceTransformSync()) {
+            dynamicsWorld->removeRigidBody(rigidBodyComp->GetBulletRigidBody());
+            rigidBodyComp->SetPosition(worldPos);
+            rigidBodyComp->SetOrientation(worldOrientation);
+            rigidBodyComp->GetBulletRigidBody()->activate(true); // To wake up from potentially sleeping state
+            dynamicsWorld->addRigidBody(rigidBodyComp->GetBulletRigidBody());
+            rigidBodyComp->SetForceTransformSync(false);
+        }
     }
 
     dynamicsWorld->stepSimulation(deltaTime, 10);

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -118,6 +118,8 @@ Component::RigidBody* PhysicsManager::CreateRigidBody(Entity* owner) {
     auto shapeComp = comp->entity->GetComponent<Component::Shape>();
     if (shapeComp) {
         comp->GetBulletRigidBody()->setCollisionShape(shapeComp->GetShape()->GetShape());
+        comp->SetMass(1.0f);
+        dynamicsWorld->addRigidBody(comp->GetBulletRigidBody());
     }
 
     return comp;
@@ -137,6 +139,8 @@ Component::RigidBody* PhysicsManager::CreateRigidBody(Entity* owner, const Json:
     auto shapeComp = comp->entity->GetComponent<Component::Shape>();
     if (shapeComp) {
         comp->GetBulletRigidBody()->setCollisionShape(shapeComp->GetShape()->GetShape());
+        comp->SetMass(mass);
+        dynamicsWorld->addRigidBody(comp->GetBulletRigidBody());
     }
 
     return comp;
@@ -152,6 +156,8 @@ Component::Shape* PhysicsManager::CreateShape(Entity* owner) {
     auto rigidBodyComp = comp->entity->GetComponent<Component::RigidBody>();
     if (rigidBodyComp) {
         rigidBodyComp->GetBulletRigidBody()->setCollisionShape(comp->GetShape()->GetShape());
+        rigidBodyComp->SetMass(rigidBodyComp->GetMass());
+        dynamicsWorld->addRigidBody(rigidBodyComp->GetBulletRigidBody());
     }
 
     return comp;
@@ -202,6 +208,8 @@ Component::Shape* PhysicsManager::CreateShape(Entity* owner, const Json::Value& 
     auto rigidBodyComp = comp->entity->GetComponent<Component::RigidBody>();
     if (rigidBodyComp) {
         rigidBodyComp->GetBulletRigidBody()->setCollisionShape(comp->GetShape()->GetShape());
+        rigidBodyComp->SetMass(rigidBodyComp->GetMass());
+        dynamicsWorld->addRigidBody(rigidBodyComp->GetBulletRigidBody());
     }
 
     return comp;

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -231,6 +231,14 @@ void PhysicsManager::SetMass(Component::RigidBody* comp, float mass) {
         comp->SetMass(mass);
 }
 
+void PhysicsManager::MakeKinematic(Component::RigidBody* comp) {
+    comp->MakeKinematic();
+}
+
+void PhysicsManager::MakeDynamic(Component::RigidBody* comp) {
+    comp->MakeDynamic();
+}
+
 const std::vector<Component::Shape*>& PhysicsManager::GetShapeComponents() const {
     return shapeComponents.GetAll();
 }

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -130,6 +130,10 @@ Component::RigidBody* PhysicsManager::CreateRigidBody(Entity* owner, const Json:
     auto mass = node.get("mass", 1.0f).asFloat();
     comp->NewBulletRigidBody(mass);
 
+    auto kinematic = node.get("kinematic", false).asFloat();
+    if (kinematic)
+        comp->MakeKinematic();
+
     auto shapeComp = comp->entity->GetComponent<Component::Shape>();
     if (shapeComp) {
         comp->GetBulletRigidBody()->setCollisionShape(shapeComp->GetShape()->GetShape());

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -251,6 +251,10 @@ void PhysicsManager::MakeDynamic(Component::RigidBody* comp) {
     comp->MakeDynamic();
 }
 
+void PhysicsManager::ForceTransformSync(Component::RigidBody* comp) {
+    comp->SetForceTransformSync(true);
+}
+
 const std::vector<Component::Shape*>& PhysicsManager::GetShapeComponents() const {
     return shapeComponents.GetAll();
 }

--- a/src/Engine/Manager/PhysicsManager.hpp
+++ b/src/Engine/Manager/PhysicsManager.hpp
@@ -129,6 +129,19 @@ class PhysicsManager {
          */
         ENGINE_API void SetMass(Component::RigidBody* comp, float mass);
 
+        /// Turn a rigid body into a kinematic object, putting movement in the
+        /// control of the programmer.
+        /**
+         * @param comp Rigid body to make kinematic.
+         */
+        ENGINE_API void MakeKinematic(Component::RigidBody* comp);
+
+        /// Turn a rigid body into a dynamic object.
+        /**
+         * @param comp Rigid body to make dynamic.
+         */
+        ENGINE_API void MakeDynamic(Component::RigidBody* comp);
+
         /// Get all shape components.
         /**
          * @return All shape components.

--- a/src/Engine/Manager/PhysicsManager.hpp
+++ b/src/Engine/Manager/PhysicsManager.hpp
@@ -142,6 +142,13 @@ class PhysicsManager {
          */
         ENGINE_API void MakeDynamic(Component::RigidBody* comp);
 
+        /// Forces a dynamic rigid body to synchronize its transform with that
+        /// of its owning entity during the next simulation iteration.
+        /**
+         * @param comp Rigid body to synchronize.
+         */
+        ENGINE_API void ForceTransformSync(Component::RigidBody* comp);
+
         /// Get all shape components.
         /**
          * @return All shape components.


### PR DESCRIPTION
This PR allows rigid bodies to become kinematic ones, meaning the programmer is responsible for setting the position and rotation. Regular rigid bodies (termed dynamic) are generally managed by Bullet without our intervention, but one can still issue a pending forced synchronization that will update a rigid body before the simulation begins next frame. This should better use rigid bodies the way Bullet intended.