### PR TITLE
Require holding Ctrl to pick

### DIFF
--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -542,7 +542,7 @@ void Editor::ControlEditorCamera(float deltaTime) {
 }
 
 void Editor::Picking() {
-    if (Input()->Triggered(InputHandler::SELECT) && !ImGui::IsMouseHoveringAnyWindow()) {
+    if (Input()->Pressed(InputHandler::CONTROL) && Input()->Triggered(InputHandler::SELECT) && !ImGui::IsMouseHoveringAnyWindow()) {
         mousePicker.UpdateProjectionMatrix(cameraEntity->GetComponent < Component::Lens>()->GetProjection(glm::vec2(MainWindow::GetInstance()->GetSize().x, MainWindow::GetInstance()->GetSize().y)));
         mousePicker.Update();
         float lastDistance = INFINITY;


### PR DESCRIPTION
Only perform mouse picking if Ctrl is held. This way mouse picking won't interfer with ImGuizmo, etc.

Fixes #744 