### PR TITLE
Make single-parameter constructors explicit

### DIFF
--- a/src/Engine/Audio/SoundBuffer.hpp
+++ b/src/Engine/Audio/SoundBuffer.hpp
@@ -18,7 +18,7 @@ namespace Audio {
             /**
              * @param soundFile The sound file containing the sound.
              */
-            ENGINE_API SoundBuffer(SoundFile* soundFile);
+            ENGINE_API explicit SoundBuffer(SoundFile* soundFile);
             
             /// Destructor.
             ENGINE_API ~SoundBuffer();

--- a/src/Engine/Audio/VorbisFile.hpp
+++ b/src/Engine/Audio/VorbisFile.hpp
@@ -14,7 +14,7 @@ namespace Audio {
             /**
              * @param filename Filename (relative or absolute) to ogg-file.
              */
-            ENGINE_API VorbisFile(const char* filename);
+            ENGINE_API explicit VorbisFile(const char* filename);
             
             /// Destructor.
             ENGINE_API ~VorbisFile() final;

--- a/src/Engine/Physics/Shape.hpp
+++ b/src/Engine/Physics/Shape.hpp
@@ -78,37 +78,37 @@ namespace Physics {
             /**
              * @param params Sphere specific parameters.
              */
-            ENGINE_API Shape(const Sphere& params);
+            ENGINE_API explicit Shape(const Sphere& params);
 
             /// Construct a plane shape.
             /**
              * @param params Plane specific parameters.
              */
-            ENGINE_API Shape(const Plane& params);
+            ENGINE_API explicit Shape(const Plane& params);
 
             /// Construct a box shape.
             /**
              * @param params Box specific parameters.
              */
-            ENGINE_API Shape(const Box& params);
+            ENGINE_API explicit Shape(const Box& params);
 
             /// Construct a cylinder shape.
             /**
              * @param params Cylinder specific parameters.
              */
-            ENGINE_API Shape(const Cylinder& params);
+            ENGINE_API explicit Shape(const Cylinder& params);
 
             /// Construct a cone shape.
             /**
              * @param params Cone specific parameters.
              */
-            ENGINE_API Shape(const Cone& params);
+            ENGINE_API explicit Shape(const Cone& params);
 
             /// Construct a capsule shape.
             /**
              * @param params Capsule specific parameters.
              */
-            ENGINE_API Shape(const Capsule& params);
+            ENGINE_API explicit Shape(const Capsule& params);
 
             /// Destructor
             ENGINE_API ~Shape();

--- a/src/Engine/Physics/Trigger.hpp
+++ b/src/Engine/Physics/Trigger.hpp
@@ -21,7 +21,7 @@ namespace Physics {
             /**
              * @param transform The world transform of the trigger volume.
              */
-            ENGINE_API Trigger(const btTransform& transform);
+            ENGINE_API explicit Trigger(const btTransform& transform);
 
         private:
             // Process observers against the trigger volume, passing the world

--- a/src/Engine/Physics/TriggerObserver.hpp
+++ b/src/Engine/Physics/TriggerObserver.hpp
@@ -33,7 +33,7 @@ namespace Physics {
             /**
              * @param body Rigid body listening to trigger.
              */
-            ENGINE_API TriggerObserver(btRigidBody& body);
+            ENGINE_API explicit TriggerObserver(btRigidBody& body);
 
             /// Get the Bullet collision object of the observing body.
             /**

--- a/src/Engine/Util/Input.hpp
+++ b/src/Engine/Util/Input.hpp
@@ -44,7 +44,7 @@ class InputHandler {
         /**
          * @param window %Window to get input for.
          */
-        ENGINE_API InputHandler(GLFWwindow* window);
+        ENGINE_API explicit InputHandler(GLFWwindow* window);
         
         /// Get currently active input handler.
         /**

--- a/src/Engine/Util/Profiling.hpp
+++ b/src/Engine/Util/Profiling.hpp
@@ -12,7 +12,7 @@ class Profiling {
         /**
          * @param name Name of the segment.
          */
-        ENGINE_API Profiling(const std::string& name);
+        ENGINE_API explicit Profiling(const std::string& name);
         
         /// End profiling.
         ENGINE_API ~Profiling();

--- a/src/Utility/Log.hpp
+++ b/src/Utility/Log.hpp
@@ -24,7 +24,7 @@ class Log {
     };
 
     /// Constructor.
-    UTILITY_API Log(const Channel channel = DEFAULT);
+    UTILITY_API explicit Log(const Channel channel = DEFAULT);
 
     /// Destructor.
     UTILITY_API ~Log();

--- a/src/Video/Buffer/FrameBuffer.hpp
+++ b/src/Video/Buffer/FrameBuffer.hpp
@@ -14,7 +14,7 @@ namespace Video {
             /**
              * @param textures Vector of %ReadWriteTexture to create a frame buffer object.
              */
-            VIDEO_API FrameBuffer(const std::vector<ReadWriteTexture*>& textures);
+            VIDEO_API explicit FrameBuffer(const std::vector<ReadWriteTexture*>& textures);
             
             /// Destructor.
             VIDEO_API ~FrameBuffer();

--- a/src/Video/Culling/Frustum.hpp
+++ b/src/Video/Culling/Frustum.hpp
@@ -16,7 +16,7 @@ namespace Video {
             /**
              * @param matrix View-projection matrix to create frustum planes from.
              */
-            VIDEO_API Frustum(const glm::mat4& matrix);
+            VIDEO_API explicit Frustum(const glm::mat4& matrix);
             
             /// Check collision between frustum and an axis-aligned bounding box.
             /**

--- a/src/Video/ParticleRenderer.hpp
+++ b/src/Video/ParticleRenderer.hpp
@@ -43,7 +43,7 @@ namespace Video {
             /**
              * @param maxParticleCount The maximum amount of particles in the buffer.
              */
-            VIDEO_API ParticleRenderer(unsigned int maxParticleCount);
+            VIDEO_API explicit ParticleRenderer(unsigned int maxParticleCount);
             
             /// Destructor.
             VIDEO_API ~ParticleRenderer();

--- a/src/Video/PostProcessing/PostProcessing.hpp
+++ b/src/Video/PostProcessing/PostProcessing.hpp
@@ -17,7 +17,7 @@ namespace Video {
             /**
              * @param rectangle %Rectangle to use for rendering.
              */
-            PostProcessing(const Geometry::Rectangle* rectangle);
+            explicit PostProcessing(const Geometry::Rectangle* rectangle);
             
             /// Destructor.
             ~PostProcessing();

--- a/src/Video/Profiling/Query.hpp
+++ b/src/Video/Profiling/Query.hpp
@@ -18,7 +18,7 @@ namespace Video {
             /**
              * @param type Specifies the type of query object.
              */
-            VIDEO_API Query(Type type);
+            VIDEO_API explicit Query(Type type);
             
             /// Destructor.
             VIDEO_API ~Query();

--- a/src/Video/RenderSurface.hpp
+++ b/src/Video/RenderSurface.hpp
@@ -15,7 +15,7 @@ namespace Video {
             /**
              * @param size Size of the new render surface.
              */
-            VIDEO_API RenderSurface(const glm::vec2& size);
+            VIDEO_API explicit RenderSurface(const glm::vec2& size);
             
             /// Destructor.
             VIDEO_API ~RenderSurface();

--- a/src/Video/Shader/ShaderProgram.hpp
+++ b/src/Video/Shader/ShaderProgram.hpp
@@ -23,7 +23,7 @@ namespace Video {
              *
              * @param shaders List of shaders to link together.
              */
-            ShaderProgram(std::initializer_list<const Shader*> shaders);
+            explicit ShaderProgram(std::initializer_list<const Shader*> shaders);
             
             /// Destructor.
             ~ShaderProgram();


### PR DESCRIPTION
Disallow implicit conversions.

Solves 2h of Sonar code smells.