### PR TITLE
Expose physics manager to scripts

### DIFF
--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -180,4 +180,12 @@ namespace Component {
     void RigidBody::SetForceTransformSync(bool sync) {
         forceTransformSync = sync;
     }
+
+    bool RigidBody::GetHaltMovement() const {
+        return haltMovement;
+    }
+
+    void RigidBody::SetHaltMovement(bool halt) {
+        haltMovement = halt;
+    }
 }

--- a/src/Engine/Component/RigidBody.hpp
+++ b/src/Engine/Component/RigidBody.hpp
@@ -123,10 +123,16 @@ namespace Component {
             bool GetForceTransformSync() const;
             void SetForceTransformSync(bool sync);
 
+            // Get/set whether a kinematic rigid body should halt its movement
+            // during the next simulation frame.
+            bool GetHaltMovement() const;
+            void SetHaltMovement(bool halt);
+
             float mass = 1.0f;
             btRigidBody* rigidBody = nullptr;
             bool kinematic = false;
             bool forceTransformSync = true; // For first frame
+            bool haltMovement = true; // True for first frame
             float friction = 0.0f;
             float rollingFriction = 0.0f;
             float spinningFriction = 0.0f;

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -58,6 +58,15 @@ void PhysicsManager::Update(float deltaTime) {
         if (rigidBodyComp->IsKinematic()) {
             rigidBodyComp->SetPosition(worldPos);
             rigidBodyComp->SetOrientation(worldOrientation);
+
+            if (rigidBodyComp->GetHaltMovement()) {
+                btTransform trans;
+                rigidBodyComp->GetBulletRigidBody()->getMotionState()->getWorldTransform(trans);
+                // Proceed twice to prevent interpolation of velocities.
+                rigidBodyComp->GetBulletRigidBody()->proceedToTransform(trans);
+                rigidBodyComp->GetBulletRigidBody()->proceedToTransform(trans);
+                rigidBodyComp->SetHaltMovement(false);
+            }
         } else if (rigidBodyComp->GetForceTransformSync()) {
             dynamicsWorld->removeRigidBody(rigidBodyComp->GetBulletRigidBody());
             rigidBodyComp->SetPosition(worldPos);

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -314,6 +314,10 @@ void PhysicsManager::ForceTransformSync(Component::RigidBody* comp) {
     comp->SetForceTransformSync(true);
 }
 
+void PhysicsManager::HaltMovement(Component::RigidBody* comp) {
+    comp->SetHaltMovement(true);
+}
+
 const std::vector<Component::Shape*>& PhysicsManager::GetShapeComponents() const {
     return shapeComponents.GetAll();
 }

--- a/src/Engine/Manager/PhysicsManager.hpp
+++ b/src/Engine/Manager/PhysicsManager.hpp
@@ -193,6 +193,12 @@ class PhysicsManager {
          */
         ENGINE_API void ForceTransformSync(Component::RigidBody* comp);
 
+        /// Halts movement of a kinematic rigid body.
+        /**
+         * @param comp Rigid body to halt.
+         */
+        ENGINE_API void HaltMovement(Component::RigidBody* comp);
+
         /// Get all shape components.
         /**
          * @return All shape components.

--- a/src/Engine/Manager/ScriptManager.cpp
+++ b/src/Engine/Manager/ScriptManager.cpp
@@ -433,6 +433,8 @@ ScriptManager::ScriptManager() {
     engine->RegisterObjectType("PhysicsManager", 0, asOBJ_REF | asOBJ_NOCOUNT);
     engine->RegisterObjectMethod("PhysicsManager", "void MakeKinematic(Component::RigidBody@)", asMETHOD(PhysicsManager, MakeKinematic), asCALL_THISCALL);
     engine->RegisterObjectMethod("PhysicsManager", "void MakeDynamic(Component::RigidBody@)", asMETHOD(PhysicsManager, MakeDynamic), asCALL_THISCALL);
+    engine->RegisterObjectMethod("PhysicsManager", "void ForceTransformSync(Component::RigidBody@)", asMETHOD(PhysicsManager, ForceTransformSync), asCALL_THISCALL);
+    engine->RegisterObjectMethod("PhysicsManager", "void HaltMovement(Component::RigidBody@)", asMETHOD(PhysicsManager, HaltMovement), asCALL_THISCALL);
 
     engine->RegisterObjectType("Hub", 0, asOBJ_REF | asOBJ_NOCOUNT);
     engine->RegisterObjectProperty("Hub", "DebugDrawingManager@ debugDrawingManager", asOFFSET(Hub, debugDrawingManager));

--- a/src/Engine/Manager/ScriptManager.cpp
+++ b/src/Engine/Manager/ScriptManager.cpp
@@ -430,10 +430,13 @@ ScriptManager::ScriptManager() {
     engine->RegisterObjectMethod("RenderManager", "void SetDitherApply(bool)", asMETHOD(RenderManager, SetDitherApply), asCALL_THISCALL);
     engine->RegisterObjectMethod("RenderManager", "bool GetDitherApply()", asMETHOD(RenderManager, GetDitherApply), asCALL_THISCALL);
 
+    engine->RegisterObjectType("PhysicsManager", 0, asOBJ_REF | asOBJ_NOCOUNT);
+
     engine->RegisterObjectType("Hub", 0, asOBJ_REF | asOBJ_NOCOUNT);
     engine->RegisterObjectProperty("Hub", "DebugDrawingManager@ debugDrawingManager", asOFFSET(Hub, debugDrawingManager));
     engine->RegisterObjectProperty("Hub", "RenderManager@ renderManager", asOFFSET(Hub, renderManager));
-    
+    engine->RegisterObjectProperty("Hub", "PhysicsManager@ physicsManager", asOFFSET(Hub, physicsManager));
+
     // Register functions.
     engine->RegisterGlobalFunction("void print(const string &in)", asFUNCTION(print), asCALL_CDECL);
     engine->RegisterGlobalFunction("void RestartScene()", asFUNCTION(RestartScene), asCALL_CDECL);

--- a/src/Engine/Manager/ScriptManager.cpp
+++ b/src/Engine/Manager/ScriptManager.cpp
@@ -431,6 +431,8 @@ ScriptManager::ScriptManager() {
     engine->RegisterObjectMethod("RenderManager", "bool GetDitherApply()", asMETHOD(RenderManager, GetDitherApply), asCALL_THISCALL);
 
     engine->RegisterObjectType("PhysicsManager", 0, asOBJ_REF | asOBJ_NOCOUNT);
+    engine->RegisterObjectMethod("PhysicsManager", "void MakeKinematic(Component::RigidBody@)", asMETHOD(PhysicsManager, MakeKinematic), asCALL_THISCALL);
+    engine->RegisterObjectMethod("PhysicsManager", "void MakeDynamic(Component::RigidBody@)", asMETHOD(PhysicsManager, MakeDynamic), asCALL_THISCALL);
 
     engine->RegisterObjectType("Hub", 0, asOBJ_REF | asOBJ_NOCOUNT);
     engine->RegisterObjectProperty("Hub", "DebugDrawingManager@ debugDrawingManager", asOFFSET(Hub, debugDrawingManager));


### PR DESCRIPTION
This allows scripts to alter dynamic rigid bodies to be kinematic and vice versa. Also fixed a bug with velocity for translated kinematic objects that manifested when they were switched to dynamic ones, thus being fired away.