### PR TITLE
Relative grid settings window

### DIFF
--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -474,7 +474,7 @@ void Editor::ShowGridSettings() {
         glm::vec2 size(MainWindow::GetInstance()->GetSize());
         ImGui::SetNextWindowPos(ImVec2((int)size.x - 255 - resourceView.GetEditorWidth(), 20));
         ImGui::SetNextWindowSizeConstraints(ImVec2(255, 105), ImVec2(255, 105));
-        ImGui::Begin("Grid Settings", &showGridSettings, ImGuiWindowFlags_NoTitleBar);
+        ImGui::Begin("Grid Settings", &showGridSettings, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize);
         ImGui::DragInt("Grid Size", &gridSettings.gridSize, 1.0f, 0, 100);
         EditorSettings::GetInstance().SetLong("Grid Size", gridSettings.gridSize);
         ImGui::DragInt("Line Width", &gridSettings.lineWidth, 0.1f, 1, 5);

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -471,8 +471,9 @@ void Editor::ShowMainMenuBar(bool& play) {
 
 void Editor::ShowGridSettings() {
     if (showGridSettings) {
-        ImGui::SetNextWindowPos(ImVec2(1275, 25));
-        ImGui::SetNextWindowSizeConstraints(ImVec2(255, 150), ImVec2(255, 150));
+        glm::vec2 size(MainWindow::GetInstance()->GetSize());
+        ImGui::SetNextWindowPos(ImVec2((int)size.x - 255 - resourceView.GetEditorWidth(), 20));
+        ImGui::SetNextWindowSizeConstraints(ImVec2(255, 105), ImVec2(255, 105));
         ImGui::Begin("Grid Settings", &showGridSettings, ImGuiWindowFlags_NoTitleBar);
         ImGui::DragInt("Grid Size", &gridSettings.gridSize, 1.0f, 0, 100);
         EditorSettings::GetInstance().SetLong("Grid Size", gridSettings.gridSize);

--- a/src/Editor/GUI/ResourceView.cpp
+++ b/src/Editor/GUI/ResourceView.cpp
@@ -216,6 +216,10 @@ SceneEditor& ResourceView::GetScene() {
     return sceneEditor;
 }
 
+int ResourceView::GetEditorWidth() const {
+    return editorWidth;
+}
+
 bool ResourceView::ShowResourceFolder(ResourceList::ResourceFolder& folder, const string& path) {
     string imguiName = folder.name + "##F--" + path;
     bool opened = ImGui::TreeNode(imguiName.c_str());

--- a/src/Editor/GUI/ResourceView.hpp
+++ b/src/Editor/GUI/ResourceView.hpp
@@ -65,6 +65,12 @@ namespace GUI {
              */
             SceneEditor& GetScene();
             
+            /// Get the width of the right-side editor (entity, script, etc.).
+            /**
+             * @return The width of the editor.
+             */
+            int GetEditorWidth() const;
+            
         private:
             bool ShowResourceFolder(ResourceList::ResourceFolder& folder, const std::string& path);
             bool ShowResource(ResourceList::ResourceFolder& folder, ResourceList::Resource& resource, const std::string& path);


### PR DESCRIPTION
Show grid settings window relative to other windows rather than at hardcoded position. This means it will actually be visible/interactable at lower window sizes.

Fixes #480 