### PR TITLE
Ghost objects to disable collision response

### DIFF
--- a/src/Editor/GUI/Editors/RigidBodyEditor.cpp
+++ b/src/Editor/GUI/Editors/RigidBodyEditor.cpp
@@ -50,6 +50,10 @@ namespace GUI {
                     Managers().physicsManager->MakeDynamic(comp);
             }
 
+            bool ghost = comp->IsGhost();
+            if (ImGui::Checkbox("Ghost", &ghost))
+                Managers().physicsManager->SetGhost(comp, ghost);
+
             ImGui::Unindent();
         }
         else {

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -1,4 +1,5 @@
 #include <btBulletDynamicsCommon.h>
+#include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #include "../Physics/GlmConversion.hpp"
 #include "RigidBody.hpp"
 
@@ -69,6 +70,8 @@ namespace Component {
         btRigidBody::btRigidBodyConstructionInfo constructionInfo(mass, motionState, nullptr, btVector3(0, 0, 0));
         rigidBody = new btRigidBody(constructionInfo);
         rigidBody->setUserPointer(this);
+
+        ghostObject = new btGhostObject();
     }
 
     void RigidBody::Destroy() {
@@ -76,6 +79,8 @@ namespace Component {
             delete rigidBody->getMotionState();
             delete rigidBody;
         }
+
+        delete ghostObject;
     }
 
     glm::vec3 RigidBody::GetPosition() const {
@@ -175,6 +180,10 @@ namespace Component {
     void RigidBody::MakeDynamic() {
         rigidBody->setCollisionFlags(rigidBody->getCollisionFlags() & ~btCollisionObject::CF_KINEMATIC_OBJECT);
         kinematic = false;
+    }
+
+    void RigidBody::SetGhost(bool ghost) {
+        this->ghost = ghost;
     }
 
     bool RigidBody::GetForceTransformSync() const {

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -175,11 +175,13 @@ namespace Component {
     void RigidBody::MakeKinematic() {
         rigidBody->setCollisionFlags(rigidBody->getCollisionFlags() | btCollisionObject::CF_KINEMATIC_OBJECT);
         kinematic = true;
+        ghost = false;
     }
 
     void RigidBody::MakeDynamic() {
         rigidBody->setCollisionFlags(rigidBody->getCollisionFlags() & ~btCollisionObject::CF_KINEMATIC_OBJECT);
         kinematic = false;
+        ghost = false;
     }
 
     void RigidBody::SetGhost(bool ghost) {

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -1,6 +1,7 @@
 #include <btBulletDynamicsCommon.h>
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #include "../Physics/GlmConversion.hpp"
+#include "../Physics/Shape.hpp"
 #include "RigidBody.hpp"
 
 #ifdef USINGMEMTRACK
@@ -81,6 +82,12 @@ namespace Component {
         }
 
         delete ghostObject;
+    }
+
+    void RigidBody::SetCollisionShape(std::shared_ptr<Physics::Shape> shape) {
+        this->shape = shape;
+        rigidBody->setCollisionShape(shape->GetShape());
+        ghostObject->setCollisionShape(shape->GetShape());
     }
 
     glm::vec3 RigidBody::GetPosition() const {

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -92,7 +92,9 @@ namespace Component {
 
     glm::vec3 RigidBody::GetPosition() const {
         btTransform trans;
-        if (IsKinematic())
+        if (ghost)
+            trans = ghostObject->getWorldTransform();
+        else if (IsKinematic())
             rigidBody->getMotionState()->getWorldTransform(trans);
         else
             trans = rigidBody->getWorldTransform();
@@ -101,6 +103,10 @@ namespace Component {
     }
 
     void RigidBody::SetPosition(const glm::vec3& pos) {
+        btTransform trans = ghostObject->getWorldTransform();
+        trans.setOrigin(Physics::glmToBt(pos));
+        ghostObject->setWorldTransform(trans);
+
         if (IsKinematic()) {
             btTransform trans;
             rigidBody->getMotionState()->getWorldTransform(trans);
@@ -115,7 +121,9 @@ namespace Component {
 
     glm::quat RigidBody::GetOrientation() const {
         btTransform trans;
-        if (IsKinematic())
+        if (ghost)
+            trans = ghostObject->getWorldTransform();
+        else if (IsKinematic())
             rigidBody->getMotionState()->getWorldTransform(trans);
         else
             trans = rigidBody->getWorldTransform();
@@ -124,6 +132,10 @@ namespace Component {
     }
 
     void RigidBody::SetOrientation(const glm::quat& rotation) {
+        btTransform trans = ghostObject->getWorldTransform();
+        trans.setRotation(Physics::glmToBt(rotation));
+        ghostObject->setWorldTransform(trans);
+
         if (IsKinematic()) {
             btTransform trans;
             rigidBody->getMotionState()->getWorldTransform(trans);

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -31,6 +31,10 @@ namespace Component {
         return kinematic;
     }
 
+    bool RigidBody::IsGhost() const {
+        return ghost;
+    }
+
     float RigidBody::GetFriction() const {
         return friction;
     }

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -23,6 +23,7 @@ namespace Component {
         component["linearDamping"] = linearDamping;
         component["angularDamping"] = angularDamping;
         component["kinematic"] = kinematic;
+        component["ghost"] = ghost;
         return component;
     }
 

--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -59,6 +59,10 @@ namespace Component {
         return rigidBody;
     }
 
+    btCollisionObject* RigidBody::GetBulletCollisionObject() {
+        return ghost ? ghostObject : static_cast<btCollisionObject*>(rigidBody);
+    }
+
     void RigidBody::NewBulletRigidBody(float mass) {
         Destroy();
 

--- a/src/Engine/Component/RigidBody.hpp
+++ b/src/Engine/Component/RigidBody.hpp
@@ -5,6 +5,7 @@
 #include "SuperComponent.hpp"
 #include "../linking.hpp"
 
+class btCollisionObject;
 class btGhostObject;
 class btRigidBody;
 class PhysicsManager;
@@ -83,6 +84,11 @@ namespace Component {
             // Get the underlying Bullet rigid body. If none has been set,
             // nullptr is returned.
             btRigidBody* GetBulletRigidBody();
+
+            // Get the underlying Bullet collision object. If none has been
+            // set, nullptr is returned. If the rigid body is not a ghost,
+            // the returned collision object is the rigid body.
+            btCollisionObject* GetBulletCollisionObject();
 
             // Creates the underlying Bullet rigid body. Mass is provided in
             // units of kilograms.

--- a/src/Engine/Component/RigidBody.hpp
+++ b/src/Engine/Component/RigidBody.hpp
@@ -4,6 +4,7 @@
 #include "SuperComponent.hpp"
 #include "../linking.hpp"
 
+class btGhostObject;
 class btRigidBody;
 class PhysicsManager;
 
@@ -117,6 +118,7 @@ namespace Component {
 
             void MakeKinematic();
             void MakeDynamic();
+            void SetGhost(bool ghost);
 
             // Get/set whether a dynamic rigid body should synchronize its
             // transform against the owning entity during the next simulation.
@@ -130,6 +132,7 @@ namespace Component {
 
             float mass = 1.0f;
             btRigidBody* rigidBody = nullptr;
+            btGhostObject* ghostObject = nullptr;
             bool kinematic = false;
             bool forceTransformSync = true; // For first frame
             bool haltMovement = true; // True for first frame
@@ -139,5 +142,6 @@ namespace Component {
             float restitution = 0.0f;
             float linearDamping = 0.0f;
             float angularDamping = 0.0f;
+            bool ghost = false;
     };
 }

--- a/src/Engine/Component/RigidBody.hpp
+++ b/src/Engine/Component/RigidBody.hpp
@@ -42,6 +42,15 @@ namespace Component {
              */
             ENGINE_API bool IsKinematic() const;
 
+            /// Return a value indicating whether the rigid body is a ghost
+            /// object, meaning that it disregards all collisions and only act
+            /// as a collider for trigger purposes. Similar to a kinematic
+            /// rigid body, movement is determined from the owning entity.
+            /**
+             * @return True if ghost, false otherwise.
+             */
+            ENGINE_API bool IsGhost() const;
+
             /// Get the friction coefficient of the rigid body. Note that this
             /// does not necessarily match the real world as objects don't have
             /// one single value for friction.

--- a/src/Engine/Component/RigidBody.hpp
+++ b/src/Engine/Component/RigidBody.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <glm/glm.hpp>
+#include <memory>
 #include "SuperComponent.hpp"
 #include "../linking.hpp"
 
@@ -9,6 +10,7 @@ class btRigidBody;
 class PhysicsManager;
 
 namespace Physics {
+    class Shape;
     class Trigger;
 }
 
@@ -89,6 +91,8 @@ namespace Component {
             // Destroy resources completely.
             void Destroy();
 
+            void SetCollisionShape(std::shared_ptr<Physics::Shape> shape);
+
             // Get the position of a rigid body.
             glm::vec3 GetPosition() const;
 
@@ -143,5 +147,6 @@ namespace Component {
             float linearDamping = 0.0f;
             float angularDamping = 0.0f;
             bool ghost = false;
+            std::shared_ptr<Physics::Shape> shape;
     };
 }

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -383,10 +383,14 @@ void PhysicsManager::MakeDynamic(Component::RigidBody* comp) {
 }
 
 void PhysicsManager::SetGhost(Component::RigidBody* comp, bool ghost) {
-    if (!comp->ghost) {
+    if (ghost && !comp->ghost) {
         dynamicsWorld->removeRigidBody(comp->GetBulletRigidBody());
         comp->SetGhost(ghost);
         dynamicsWorld->addCollisionObject(comp->GetBulletCollisionObject());
+    } else if (!ghost && comp->ghost) {
+        dynamicsWorld->removeCollisionObject(comp->GetBulletCollisionObject());
+        comp->SetGhost(ghost);
+        dynamicsWorld->addRigidBody(comp->GetBulletRigidBody());
     }
 }
 

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -212,7 +212,10 @@ Component::RigidBody* PhysicsManager::CreateRigidBody(Entity* owner, const Json:
     if (shapeComp) {
         comp->SetCollisionShape(shapeComp->GetShape());
         comp->SetMass(mass);
-        dynamicsWorld->addRigidBody(comp->GetBulletRigidBody());
+        if (ghost)
+            dynamicsWorld->addCollisionObject(comp->GetBulletCollisionObject());
+        else
+            dynamicsWorld->addRigidBody(comp->GetBulletRigidBody());
     }
 
     return comp;
@@ -229,7 +232,10 @@ Component::Shape* PhysicsManager::CreateShape(Entity* owner) {
     if (rigidBodyComp) {
         rigidBodyComp->SetCollisionShape(comp->GetShape());
         rigidBodyComp->SetMass(rigidBodyComp->GetMass());
-        dynamicsWorld->addRigidBody(rigidBodyComp->GetBulletRigidBody());
+        if (rigidBodyComp->ghost)
+            dynamicsWorld->addCollisionObject(rigidBodyComp->GetBulletCollisionObject());
+        else
+            dynamicsWorld->addRigidBody(rigidBodyComp->GetBulletRigidBody());
     }
 
     return comp;
@@ -281,7 +287,10 @@ Component::Shape* PhysicsManager::CreateShape(Entity* owner, const Json::Value& 
     if (rigidBodyComp) {
         rigidBodyComp->SetCollisionShape(comp->GetShape());
         rigidBodyComp->SetMass(rigidBodyComp->GetMass());
-        dynamicsWorld->addRigidBody(rigidBodyComp->GetBulletRigidBody());
+        if (rigidBodyComp->ghost)
+            dynamicsWorld->addCollisionObject(rigidBodyComp->GetBulletCollisionObject());
+        else
+            dynamicsWorld->addRigidBody(rigidBodyComp->GetBulletRigidBody());
     }
 
     return comp;
@@ -373,7 +382,10 @@ const std::vector<Component::Shape*>& PhysicsManager::GetShapeComponents() const
 void PhysicsManager::ClearKilledComponents() {
     rigidBodyComponents.ClearKilled(
         [this](Component::RigidBody* body) {
-            dynamicsWorld->removeRigidBody(body->GetBulletRigidBody());
+            if (body->ghost)
+                dynamicsWorld->removeCollisionObject(body->GetBulletCollisionObject());
+            else
+                dynamicsWorld->removeRigidBody(body->GetBulletRigidBody());
         });
     shapeComponents.ClearKilled();
 }

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -360,11 +360,34 @@ void PhysicsManager::SetAngularDamping(Component::RigidBody* comp, float damping
 }
 
 void PhysicsManager::MakeKinematic(Component::RigidBody* comp) {
+    bool wasGhost = comp->ghost;
+
+    if (wasGhost)
+        dynamicsWorld->removeCollisionObject(comp->GetBulletCollisionObject());
+
     comp->MakeKinematic();
+
+    if (wasGhost)
+        dynamicsWorld->addRigidBody(comp->GetBulletRigidBody());
 }
 
 void PhysicsManager::MakeDynamic(Component::RigidBody* comp) {
+    bool wasGhost = comp->ghost;
+    if (wasGhost)
+        dynamicsWorld->removeCollisionObject(comp->GetBulletCollisionObject());
+
     comp->MakeDynamic();
+
+    if (wasGhost)
+        dynamicsWorld->addRigidBody(comp->GetBulletRigidBody());
+}
+
+void PhysicsManager::SetGhost(Component::RigidBody* comp, bool ghost) {
+    if (!comp->ghost) {
+        dynamicsWorld->removeRigidBody(comp->GetBulletRigidBody());
+        comp->SetGhost(ghost);
+        dynamicsWorld->addCollisionObject(comp->GetBulletCollisionObject());
+    }
 }
 
 void PhysicsManager::ForceTransformSync(Component::RigidBody* comp) {

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -204,6 +204,10 @@ Component::RigidBody* PhysicsManager::CreateRigidBody(Entity* owner, const Json:
     if (kinematic)
         comp->MakeKinematic();
 
+    auto ghost = node.get("ghost", false).asBool();
+    if (ghost)
+        comp->SetGhost(ghost);
+
     auto shapeComp = comp->entity->GetComponent<Component::Shape>();
     if (shapeComp) {
         comp->SetCollisionShape(shapeComp->GetShape());

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -1,6 +1,7 @@
 #include "PhysicsManager.hpp"
 
 #include <btBulletDynamicsCommon.h>
+#include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #include <glm/gtx/quaternion.hpp>
 #include "../Component/RigidBody.hpp"
 #include "../Component/Shape.hpp"
@@ -59,7 +60,12 @@ void PhysicsManager::Update(float deltaTime) {
 
         auto worldPos = rigidBodyComp->entity->GetWorldPosition();
         auto worldOrientation = rigidBodyComp->entity->GetWorldOrientation();
-        if (rigidBodyComp->IsKinematic()) {
+        if (rigidBodyComp->ghost) {
+            rigidBodyComp->SetPosition(worldPos);
+            rigidBodyComp->SetOrientation(worldOrientation);
+            rigidBodyComp->ghostObject->activate(true);
+        }
+        else if (rigidBodyComp->IsKinematic()) {
             rigidBodyComp->SetPosition(worldPos);
             rigidBodyComp->SetOrientation(worldOrientation);
 
@@ -95,7 +101,7 @@ void PhysicsManager::UpdateEntityTransforms() {
 
         Entity* entity = rigidBodyComp->entity;
         auto trans = rigidBodyComp->GetBulletRigidBody()->getWorldTransform();
-        if (!rigidBodyComp->IsKinematic()) {
+        if (!rigidBodyComp->ghost && !rigidBodyComp->IsKinematic()) {
             entity->SetWorldPosition(Physics::btToGlm(trans.getOrigin()));
             entity->SetWorldOrientation(Physics::btToGlm(trans.getRotation()));
         }

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -161,7 +161,7 @@ Component::RigidBody* PhysicsManager::CreateRigidBody(Entity* owner) {
 
     auto shapeComp = comp->entity->GetComponent<Component::Shape>();
     if (shapeComp) {
-        comp->GetBulletRigidBody()->setCollisionShape(shapeComp->GetShape()->GetShape());
+        comp->SetCollisionShape(shapeComp->GetShape());
         comp->SetMass(1.0f);
         dynamicsWorld->addRigidBody(comp->GetBulletRigidBody());
     }
@@ -200,7 +200,7 @@ Component::RigidBody* PhysicsManager::CreateRigidBody(Entity* owner, const Json:
 
     auto shapeComp = comp->entity->GetComponent<Component::Shape>();
     if (shapeComp) {
-        comp->GetBulletRigidBody()->setCollisionShape(shapeComp->GetShape()->GetShape());
+        comp->SetCollisionShape(shapeComp->GetShape());
         comp->SetMass(mass);
         dynamicsWorld->addRigidBody(comp->GetBulletRigidBody());
     }
@@ -217,7 +217,7 @@ Component::Shape* PhysicsManager::CreateShape(Entity* owner) {
 
     auto rigidBodyComp = comp->entity->GetComponent<Component::RigidBody>();
     if (rigidBodyComp) {
-        rigidBodyComp->GetBulletRigidBody()->setCollisionShape(comp->GetShape()->GetShape());
+        rigidBodyComp->SetCollisionShape(comp->GetShape());
         rigidBodyComp->SetMass(rigidBodyComp->GetMass());
         dynamicsWorld->addRigidBody(rigidBodyComp->GetBulletRigidBody());
     }
@@ -269,7 +269,7 @@ Component::Shape* PhysicsManager::CreateShape(Entity* owner, const Json::Value& 
 
     auto rigidBodyComp = comp->entity->GetComponent<Component::RigidBody>();
     if (rigidBodyComp) {
-        rigidBodyComp->GetBulletRigidBody()->setCollisionShape(comp->GetShape()->GetShape());
+        rigidBodyComp->SetCollisionShape(comp->GetShape());
         rigidBodyComp->SetMass(rigidBodyComp->GetMass());
         dynamicsWorld->addRigidBody(rigidBodyComp->GetBulletRigidBody());
     }
@@ -296,7 +296,7 @@ void PhysicsManager::SetShape(Component::Shape* comp, std::shared_ptr<::Physics:
 
     auto rigidBodyComp = comp->entity->GetComponent<Component::RigidBody>();
     if (rigidBodyComp)
-        rigidBodyComp->GetBulletRigidBody()->setCollisionShape(comp->GetShape()->GetShape());
+        rigidBodyComp->SetCollisionShape(comp->GetShape());
 }
 
 float PhysicsManager::GetMass(Component::RigidBody* comp) {

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -111,7 +111,7 @@ void PhysicsManager::UpdateEntityTransforms() {
 void PhysicsManager::OnTriggerEnter(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object, std::function<void()> callback) {
     // Add the callback to the trigger observer
     trigger.Open(triggerLockBoxKey, [object, &callback](Physics::Trigger& trigger) {
-        trigger.ForObserver(object->GetBulletRigidBody(), [&callback](Physics::TriggerObserver& observer) {
+        trigger.ForObserver(object->GetBulletCollisionObject(), [&callback](Physics::TriggerObserver& observer) {
             observer.OnEnter(callback);
         });
     });
@@ -119,7 +119,7 @@ void PhysicsManager::OnTriggerEnter(Utility::LockBox<Physics::Trigger> trigger, 
 
 void PhysicsManager::ForgetTriggerEnter(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object) {
     trigger.Open(triggerLockBoxKey, [object](Physics::Trigger& trigger) {
-        trigger.ForObserver(object->GetBulletRigidBody(), [](Physics::TriggerObserver& observer) {
+        trigger.ForObserver(object->GetBulletCollisionObject(), [](Physics::TriggerObserver& observer) {
             observer.ForgetEnter();
         });
     });
@@ -128,7 +128,7 @@ void PhysicsManager::ForgetTriggerEnter(Utility::LockBox<Physics::Trigger> trigg
 void PhysicsManager::OnTriggerRetain(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object, std::function<void()> callback) {
     // Add the callback to the trigger observer
     trigger.Open(triggerLockBoxKey, [object, &callback](Physics::Trigger& trigger) {
-        trigger.ForObserver(object->GetBulletRigidBody(), [&callback](::Physics::TriggerObserver& observer) {
+        trigger.ForObserver(object->GetBulletCollisionObject(), [&callback](::Physics::TriggerObserver& observer) {
             observer.OnRetain(callback);
         });
     });
@@ -136,7 +136,7 @@ void PhysicsManager::OnTriggerRetain(Utility::LockBox<Physics::Trigger> trigger,
 
 void PhysicsManager::ForgetTriggerRetain(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object) {
     trigger.Open(triggerLockBoxKey, [object](Physics::Trigger& trigger) {
-        trigger.ForObserver(object->GetBulletRigidBody(), [](Physics::TriggerObserver& observer) {
+        trigger.ForObserver(object->GetBulletCollisionObject(), [](Physics::TriggerObserver& observer) {
             observer.ForgetRetain();
         });
     });
@@ -145,7 +145,7 @@ void PhysicsManager::ForgetTriggerRetain(Utility::LockBox<Physics::Trigger> trig
 void PhysicsManager::OnTriggerLeave(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object, std::function<void()> callback) {
     // Add the callback to the trigger observer
     trigger.Open(triggerLockBoxKey, [object, &callback](Physics::Trigger& trigger) {
-        trigger.ForObserver(object->GetBulletRigidBody(), [&callback](::Physics::TriggerObserver& observer) {
+        trigger.ForObserver(object->GetBulletCollisionObject(), [&callback](::Physics::TriggerObserver& observer) {
             observer.OnLeave(callback);
         });
     });
@@ -153,7 +153,7 @@ void PhysicsManager::OnTriggerLeave(Utility::LockBox<Physics::Trigger> trigger, 
 
 void PhysicsManager::ForgetTriggerLeave(Utility::LockBox<Physics::Trigger> trigger, Component::RigidBody* object) {
     trigger.Open(triggerLockBoxKey, [object](Physics::Trigger& trigger) {
-        trigger.ForObserver(object->GetBulletRigidBody(), [](Physics::TriggerObserver& observer) {
+        trigger.ForObserver(object->GetBulletCollisionObject(), [](Physics::TriggerObserver& observer) {
             observer.ForgetLeave();
         });
     });

--- a/src/Engine/Manager/PhysicsManager.hpp
+++ b/src/Engine/Manager/PhysicsManager.hpp
@@ -223,8 +223,8 @@ class PhysicsManager {
         /**
          * @param comp Rigid body to alter state of.
          * @param ghost True: makes the rigid object a ghost, disregarding all
-         collisions. False: disables ghost state, reverting to kinematic or
-         dynamic as before.
+         * collisions. False: disables ghost state, reverting to kinematic or
+         * dynamic as before.
          */
         ENGINE_API void SetGhost(Component::RigidBody* comp, bool ghost);
 

--- a/src/Engine/Manager/PhysicsManager.hpp
+++ b/src/Engine/Manager/PhysicsManager.hpp
@@ -219,6 +219,15 @@ class PhysicsManager {
          */
         ENGINE_API void MakeDynamic(Component::RigidBody* comp);
 
+        /// Enables/disables ghost functionality on a rigid body.
+        /**
+         * @param comp Rigid body to alter state of.
+         * @param ghost True: makes the rigid object a ghost, disregarding all
+         collisions. False: disables ghost state, reverting to kinematic or
+         dynamic as before.
+         */
+        ENGINE_API void SetGhost(Component::RigidBody* comp, bool ghost);
+
         /// Forces a dynamic rigid body to synchronize its transform with that
         /// of its owning entity during the next simulation iteration.
         /**

--- a/src/Engine/Physics/Shape.hpp
+++ b/src/Engine/Physics/Shape.hpp
@@ -7,6 +7,10 @@
 class btCollisionShape;
 class PhysicsManager;
 
+namespace Component {
+    class RigidBody;
+}
+
 namespace Physics {
     class Trigger;
 
@@ -14,6 +18,7 @@ namespace Physics {
     /// underlying types.
     class Shape {
         friend class ::PhysicsManager;
+        friend class ::Component::RigidBody;
         friend class Trigger;
 
         public:

--- a/src/Engine/Physics/Trigger.cpp
+++ b/src/Engine/Physics/Trigger.cpp
@@ -22,7 +22,7 @@ namespace Physics {
         }
     }
 
-    void Trigger::ForObserver(btRigidBody* body, const std::function<void(TriggerObserver& observer)>& fun) {
+    void Trigger::ForObserver(btCollisionObject* body, const std::function<void(TriggerObserver& observer)>& fun) {
         auto obs = std::find_if(observers.begin(), observers.end(), [body](std::unique_ptr<Physics::TriggerObserver>& ptr) {
             return body == ptr->GetBulletCollisionObject();
         });

--- a/src/Engine/Physics/Trigger.hpp
+++ b/src/Engine/Physics/Trigger.hpp
@@ -27,7 +27,7 @@ namespace Physics {
             // Get access to a particular observer of the trigger to work with
             // it in a user-defined way. If the observer is not present, one
             // will be created.
-            void ForObserver(btRigidBody* body, const std::function<void(TriggerObserver&)>& fun);
+            void ForObserver(btCollisionObject* body, const std::function<void(TriggerObserver&)>& fun);
 
             void SetCollisionShape(std::shared_ptr<Shape> shape);
             void SetPosition(const btVector3& position);

--- a/src/Engine/Physics/TriggerObserver.cpp
+++ b/src/Engine/Physics/TriggerObserver.cpp
@@ -7,7 +7,7 @@
 #endif
 
 namespace Physics {
-    TriggerObserver::TriggerObserver(btRigidBody& body)
+    TriggerObserver::TriggerObserver(btCollisionObject& body)
     : btCollisionWorld::ContactResultCallback(), rigidBody(body) {
 
     }

--- a/src/Engine/Physics/TriggerObserver.hpp
+++ b/src/Engine/Physics/TriggerObserver.hpp
@@ -4,7 +4,7 @@
 #include <functional>
 #include "../linking.hpp"
 
-class btRigidBody;
+class btCollisionObject;
 
 namespace Physics {
     /// Represents an object that listens to intersections against a trigger
@@ -33,7 +33,7 @@ namespace Physics {
             /**
              * @param body Rigid body listening to trigger.
              */
-            ENGINE_API explicit TriggerObserver(btRigidBody& body);
+            ENGINE_API explicit TriggerObserver(btCollisionObject& body);
 
             /// Get the Bullet collision object of the observing body.
             /**
@@ -93,7 +93,7 @@ namespace Physics {
                 const btCollisionObjectWrapper* colObj1, int partId1, int index1) override;
 
             IntersectionPhase phase = IntersectionPhase::None;
-            btRigidBody& rigidBody;
+            btCollisionObject& rigidBody;
             // Control value to determine whether an intersection happened
             // during this frame. This is used to determine the new phase.
             bool didCallback = false;


### PR DESCRIPTION
Adds ability to mark a rigid body as a ghost (just as we check kinematic) in the editor. This makes the rigid body disregard all collisions; it doesn't interact with other rigid bodies at all. This functionality is useful if we want to get trigger events for a rigid body but are not interested in actually colliding objects.

Disclaimer: The desired approach would be to put this functionality in the shape component instead, and have trigger components listen for shapes. In order to progress towards a delivery, this solution is fine for our purposes.