### PR TITLE
Fix ghost objects not actually being ghosts.

### DIFF
--- a/src/Engine/Component/RigidBody.cpp
+++ b/src/Engine/Component/RigidBody.cpp
@@ -82,6 +82,8 @@ namespace Component {
         rigidBody->setUserPointer(this);
 
         ghostObject = new btGhostObject();
+        ghostObject->setWorldTransform(btTransform(btQuaternion(0, 0, 0, 1), btVector3(0, 0, 0)));
+        ghostObject->setCollisionFlags(ghostObject->getCollisionFlags() | btCollisionObject::CF_NO_CONTACT_RESPONSE);
     }
 
     void RigidBody::Destroy() {


### PR DESCRIPTION
It turns out that #842 doesn't actually result in ghosts; collisions still interact with dynamic objects, despite finding information to the contrary.  Apparently `CF_NO_CONTACT_RESPONSE` affects other objects instead of marking that an object should have no contact response.