### PR TITLE
Store uniform locations

### DIFF
--- a/src/Video/DebugDrawing.cpp
+++ b/src/Video/DebugDrawing.cpp
@@ -22,6 +22,12 @@ DebugDrawing::DebugDrawing() {
     delete vertexShader;
     delete fragmentShader;
     
+    // Get uniform locations.
+    viewProjectionLocation = shaderProgram->GetUniformLocation("viewProjection");
+    modelLocation = shaderProgram->GetUniformLocation("model");
+    colorLocation = shaderProgram->GetUniformLocation("color");
+    sizeLocation = shaderProgram->GetUniformLocation("size");
+    
     // Create point vertex array.
     glBindVertexArray(0);
     
@@ -132,7 +138,7 @@ DebugDrawing::~DebugDrawing() {
 
 void DebugDrawing::StartDebugDrawing(const glm::mat4& viewProjectionMatrix) {
     shaderProgram->Use();
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("viewProjection"), 1, GL_FALSE, &viewProjectionMatrix[0][0]);
+    glUniformMatrix4fv(viewProjectionLocation, 1, GL_FALSE, &viewProjectionMatrix[0][0]);
 }
 
 void DebugDrawing::DrawPoint(const Point& point) {
@@ -140,10 +146,10 @@ void DebugDrawing::DrawPoint(const Point& point) {
     
     glm::mat4 model(glm::translate(glm::mat4(), point.position));
     
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &model[0][0]);
+    glUniformMatrix4fv(modelLocation, 1, GL_FALSE, &model[0][0]);
     point.depthTesting ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
-    glUniform3fv(shaderProgram->GetUniformLocation("color"), 1, &point.color[0]);
-    glUniform1f(shaderProgram->GetUniformLocation("size"), point.size);
+    glUniform3fv(colorLocation, 1, &point.color[0]);
+    glUniform1f(sizeLocation, point.size);
     glDrawArrays(GL_POINTS, 0, 1);
 }
 
@@ -152,9 +158,9 @@ void DebugDrawing::DrawLine(const Line& line) {
     
     glm::mat4 model(glm::translate(glm::mat4(), line.startPosition) * glm::scale(glm::mat4(), line.endPosition - line.startPosition));
     
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &model[0][0]);
+    glUniformMatrix4fv(modelLocation, 1, GL_FALSE, &model[0][0]);
     line.depthTesting ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
-    glUniform3fv(shaderProgram->GetUniformLocation("color"), 1, &line.color[0]);
+    glUniform3fv(colorLocation, 1, &line.color[0]);
     glLineWidth(line.width);
     glDrawArrays(GL_LINES, 0, 2);
 }
@@ -164,10 +170,10 @@ void DebugDrawing::DrawCuboid(const Cuboid& cuboid) {
     
     glm::mat4 model(cuboid.matrix * glm::scale(glm::mat4(), cuboid.dimensions));
     
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &model[0][0]);
+    glUniformMatrix4fv(modelLocation, 1, GL_FALSE, &model[0][0]);
     cuboid.depthTesting ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
-    glUniform3fv(shaderProgram->GetUniformLocation("color"), 1, &cuboid.color[0]);
-    glUniform1f(shaderProgram->GetUniformLocation("size"), 10.f);
+    glUniform3fv(colorLocation, 1, &cuboid.color[0]);
+    glUniform1f(sizeLocation, 10.f);
     glLineWidth(cuboid.lineWidth);
     glDrawArrays(GL_LINES, 0, 24);
 }
@@ -182,10 +188,10 @@ void DebugDrawing::DrawPlane(const Plane& plane) {
     model = glm::rotate(glm::mat4(), pitch, glm::vec3(1.f, 0.f, 0.f)) * model;
     model = glm::translate(glm::mat4(), plane.position) * model;
     
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &model[0][0]);
+    glUniformMatrix4fv(modelLocation, 1, GL_FALSE, &model[0][0]);
     plane.depthTesting ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
-    glUniform3fv(shaderProgram->GetUniformLocation("color"), 1, &plane.color[0]);
-    glUniform1f(shaderProgram->GetUniformLocation("size"), 10.f);
+    glUniform3fv(colorLocation, 1, &plane.color[0]);
+    glUniform1f(sizeLocation, 10.f);
     glLineWidth(plane.lineWidth);
     glDrawArrays(GL_LINES, 0, 8);
 }
@@ -200,10 +206,10 @@ void DebugDrawing::DrawCircle(const Circle& circle) {
     model = glm::rotate(glm::mat4(), pitch, glm::vec3(1.f, 0.f, 0.f)) * model;
     model = glm::translate(glm::mat4(), circle.position) * model;
     
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &model[0][0]);
+    glUniformMatrix4fv(modelLocation, 1, GL_FALSE, &model[0][0]);
     circle.depthTesting ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
-    glUniform3fv(shaderProgram->GetUniformLocation("color"), 1, &circle.color[0]);
-    glUniform1f(shaderProgram->GetUniformLocation("size"), 10.f);
+    glUniform3fv(colorLocation, 1, &circle.color[0]);
+    glUniform1f(sizeLocation, 10.f);
     glLineWidth(circle.lineWidth);
     glDrawArrays(GL_LINES, 0, circleVertexCount);
 }
@@ -214,10 +220,10 @@ void DebugDrawing::DrawSphere(const Sphere& sphere) {
     glm::mat4 model(glm::scale(glm::mat4(), glm::vec3(sphere.radius, sphere.radius, sphere.radius)));
     model = glm::translate(glm::mat4(), sphere.position) * model;
     
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &model[0][0]);
+    glUniformMatrix4fv(modelLocation, 1, GL_FALSE, &model[0][0]);
     sphere.depthTesting ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
-    glUniform3fv(shaderProgram->GetUniformLocation("color"), 1, &sphere.color[0]);
-    glUniform1f(shaderProgram->GetUniformLocation("size"), 10.f);
+    glUniform3fv(colorLocation, 1, &sphere.color[0]);
+    glUniform1f(sizeLocation, 10.f);
     glLineWidth(sphere.lineWidth);
     glDrawArrays(GL_LINES, 0, sphereVertexCount);
 }
@@ -228,10 +234,10 @@ void DebugDrawing::DrawCylinder(const Cylinder& cylinder) {
     glm::mat4 model(glm::scale(glm::mat4(), glm::vec3(cylinder.radius, cylinder.length, cylinder.radius)));
     model = cylinder.matrix * model;
     
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &model[0][0]);
+    glUniformMatrix4fv(modelLocation, 1, GL_FALSE, &model[0][0]);
     cylinder.depthTesting ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
-    glUniform3fv(shaderProgram->GetUniformLocation("color"), 1, &cylinder.color[0]);
-    glUniform1f(shaderProgram->GetUniformLocation("size"), 10.f);
+    glUniform3fv(colorLocation, 1, &cylinder.color[0]);
+    glUniform1f(sizeLocation, 10.f);
     glLineWidth(cylinder.lineWidth);
     glDrawArrays(GL_LINES, 0, cylinderVertexCount);
 }
@@ -242,10 +248,10 @@ void DebugDrawing::DrawCone(const Cone& cone) {
     glm::mat4 model(glm::scale(glm::mat4(), glm::vec3(cone.radius, cone.height, cone.radius)));
     model = cone.matrix * model;
     
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &model[0][0]);
+    glUniformMatrix4fv(modelLocation, 1, GL_FALSE, &model[0][0]);
     cone.depthTesting ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
-    glUniform3fv(shaderProgram->GetUniformLocation("color"), 1, &cone.color[0]);
-    glUniform1f(shaderProgram->GetUniformLocation("size"), 10.f);
+    glUniform3fv(colorLocation, 1, &cone.color[0]);
+    glUniform1f(sizeLocation, 10.f);
     glLineWidth(cone.lineWidth);
     glDrawArrays(GL_LINES, 0, coneVertexCount);
 }

--- a/src/Video/DebugDrawing.hpp
+++ b/src/Video/DebugDrawing.hpp
@@ -263,6 +263,13 @@ namespace Video {
             
             Video::ShaderProgram* shaderProgram;
             
+            // Uniform locations.
+            GLuint viewProjectionLocation;
+            GLuint modelLocation;
+            GLuint colorLocation;
+            GLuint sizeLocation;
+            
+            // Geometry.
             GLuint pointVertexBuffer;
             GLuint pointVertexArray;
             

--- a/src/Video/ParticleRenderer.cpp
+++ b/src/Video/ParticleRenderer.cpp
@@ -27,6 +27,13 @@ ParticleRenderer::ParticleRenderer(unsigned int maxParticleCount) {
     delete geometryShader;
     delete fragmentShader;
     
+    // Get uniform locations.
+    baseImageLocation = shaderProgram->GetUniformLocation("baseImage");
+    cameraPositionLocation = shaderProgram->GetUniformLocation("cameraPosition");
+    cameraUpLocation = shaderProgram->GetUniformLocation("cameraUp");
+    viewProjectionLocation = shaderProgram->GetUniformLocation("viewProjectionMatrix");
+    textureAtlasRowsLocation = shaderProgram->GetUniformLocation("textureAtlasRows");
+    
     // Vertex buffer
     glGenBuffers(1, &vertexBuffer);
     glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
@@ -90,17 +97,17 @@ void ParticleRenderer::Render(Texture2D* textureAtlas, unsigned int textureAtlas
     
     glBindVertexArray(vertexArray);
     
-    glUniform1i(shaderProgram->GetUniformLocation("baseImage"), 0);
+    glUniform1i(baseImageLocation, 0);
     
     // Base image texture
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, textureAtlas->GetTextureID());
     
     // Send the matrices to the shader.
-    glUniform3fv(shaderProgram->GetUniformLocation("cameraPosition"), 1, &cameraPosition[0]);
-    glUniform3fv(shaderProgram->GetUniformLocation("cameraUp"), 1, &cameraUp[0]);
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("viewProjectionMatrix"), 1, GL_FALSE, &viewProjectionMatrix[0][0]);
-    glUniform1f(shaderProgram->GetUniformLocation("textureAtlasRows"), textureAtlasRows);
+    glUniform3fv(cameraPositionLocation, 1, &cameraPosition[0]);
+    glUniform3fv(cameraUpLocation, 1, &cameraUp[0]);
+    glUniformMatrix4fv(viewProjectionLocation, 1, GL_FALSE, &viewProjectionMatrix[0][0]);
+    glUniform1f(textureAtlasRowsLocation, textureAtlasRows);
     
     // Draw the triangles
     glDrawArrays(GL_POINTS, 0, particleCount);

--- a/src/Video/ParticleRenderer.hpp
+++ b/src/Video/ParticleRenderer.hpp
@@ -70,6 +70,13 @@ namespace Video {
             ParticleRenderer(const ParticleRenderer & other) = delete;
             ShaderProgram* shaderProgram;
             
+            // Uniform locations.
+            GLuint baseImageLocation;
+            GLuint cameraPositionLocation;
+            GLuint cameraUpLocation;
+            GLuint viewProjectionLocation;
+            GLuint textureAtlasRowsLocation;
+            
             // Vertex buffer.
             GLuint vertexBuffer = 0;
             GLuint vertexArray = 0;

--- a/src/Video/PostProcessing/FXAAFilter.cpp
+++ b/src/Video/PostProcessing/FXAAFilter.cpp
@@ -19,6 +19,7 @@ FXAAFilter::FXAAFilter() {
     delete fragmentShader;
     
     screenSizeLocation = shaderProgram->GetUniformLocation("screenSize");
+    diffuseLocation = shaderProgram->GetUniformLocation("tDiffuse");
 }
 
 FXAAFilter::~FXAAFilter() {
@@ -27,6 +28,10 @@ FXAAFilter::~FXAAFilter() {
 
 ShaderProgram* FXAAFilter::GetShaderProgram() const {
     return shaderProgram;
+}
+
+GLuint FXAAFilter::GetDiffuseLocation() const {
+    return diffuseLocation;
 }
 
 void FXAAFilter::SetUniforms() {

--- a/src/Video/PostProcessing/FXAAFilter.hpp
+++ b/src/Video/PostProcessing/FXAAFilter.hpp
@@ -18,10 +18,16 @@ namespace Video {
             /**
              * @return Shader program
              */
-            Video::ShaderProgram* GetShaderProgram() const;
+            Video::ShaderProgram* GetShaderProgram() const final;
+            
+            /// Get the location of the diffuse uniform.
+            /**
+             * @return The location of the diffuse uniform.
+             */
+            GLuint GetDiffuseLocation() const final;
             
             /// Set uniforms.
-            void SetUniforms();
+            void SetUniforms() final;
             
             /// Set the screen size used when calculating FXAA.
             /**
@@ -33,6 +39,7 @@ namespace Video {
             ShaderProgram* shaderProgram;
             
             glm::vec2 screenSize;
-            GLint screenSizeLocation;
+            GLuint screenSizeLocation;
+            GLuint diffuseLocation;
     };
 }

--- a/src/Video/PostProcessing/Filter.hpp
+++ b/src/Video/PostProcessing/Filter.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <GL/glew.h>
+
 namespace Video {
     class ShaderProgram;
     
@@ -17,6 +19,12 @@ namespace Video {
              * @return Shader program
              */
             virtual ShaderProgram* GetShaderProgram() const = 0;
+            
+            /// Get the location of the diffuse uniform.
+            /**
+             * @return The location of the diffuse uniform.
+             */
+            virtual GLuint GetDiffuseLocation() const = 0;
             
             /// Set uniforms.
             virtual void SetUniforms() = 0;

--- a/src/Video/PostProcessing/PostProcessing.cpp
+++ b/src/Video/PostProcessing/PostProcessing.cpp
@@ -31,7 +31,7 @@ void PostProcessing::ApplyFilter(Video::RenderSurface* renderSurface, Video::Fil
     // Bind shaders.
     filter->GetShaderProgram()->Use();
     
-    glUniform1i(filter->GetShaderProgram()->GetUniformLocation("tDiffuse"), 0);
+    glUniform1i(filter->GetDiffuseLocation(), 0);
     renderSurface->GetColorTexture()->BindForReading(GL_TEXTURE0);
     
     glBindVertexArray(rectangle->GetVertexArray());

--- a/src/Video/RenderProgram/SkinRenderProgram.cpp
+++ b/src/Video/RenderProgram/SkinRenderProgram.cpp
@@ -39,6 +39,32 @@ SkinRenderProgram::SkinRenderProgram() {
     shadowProgram = new ShaderProgram({ vertexShader, fragmentShader });
     delete vertexShader;
     delete fragmentShader;
+    
+    // Get uniform locations.
+    shadowLightSpaceLocation = shadowProgram->GetUniformLocation("lightSpaceMatrix");
+    shadowModelLocation = shadowProgram->GetUniformLocation("model");
+    shadowBonesLocation = shadowProgram->GetUniformLocation("bones");
+    zViewProjectionLocation = zShaderProgram->GetUniformLocation("viewProjection");
+    zModelLocation = zShaderProgram->GetUniformLocation("model");
+    zBonesLocation = zShaderProgram->GetUniformLocation("bones");
+    viewProjectionLocation = shaderProgram->GetUniformLocation("viewProjection");
+    lightCountLocation = shaderProgram->GetUniformLocation("lightCount");
+    gammaLocation = shaderProgram->GetUniformLocation("gamma");
+    fogApplyLocation = shaderProgram->GetUniformLocation("fogApply");
+    fogDensityLocation = shaderProgram->GetUniformLocation("fogDensity");
+    fogColorLocation = shaderProgram->GetUniformLocation("fogColor");
+    colorFilterApplyLocation = shaderProgram->GetUniformLocation("colorFilterApply");
+    colorFilterColorLocation = shaderProgram->GetUniformLocation("colorFilterColor");
+    ditherApplyLocation = shaderProgram->GetUniformLocation("ditherApply");
+    timeLocation = shaderProgram->GetUniformLocation("time");
+    isSelectedLocation = shaderProgram->GetUniformLocation("isSelected");
+    mapAlbedoLocation = shaderProgram->GetUniformLocation("mapAlbedo");
+    mapNormalLocation = shaderProgram->GetUniformLocation("mapNormal");
+    mapMetallicLocation = shaderProgram->GetUniformLocation("mapMetallic");
+    mapRoughnessLocation = shaderProgram->GetUniformLocation("mapRoughness");
+    modelLocation = shaderProgram->GetUniformLocation("model");
+    normalLocation = shaderProgram->GetUniformLocation("normalMatrix");
+    bonesLocation = shaderProgram->GetUniformLocation("bones");
 }
 
 SkinRenderProgram::~SkinRenderProgram() {
@@ -61,7 +87,7 @@ void SkinRenderProgram::PreShadowRender(const glm::mat4& viewMatrix, const glm::
     this->viewProjectionMatrix = projectionMatrix * viewMatrix;
     this->shadowId = shadowId;
 
-    glUniformMatrix4fv(shadowProgram->GetUniformLocation("lightSpaceMatrix"), 1, GL_FALSE, &lightSpaceMatrix[0][0]);
+    glUniformMatrix4fv(shadowLightSpaceLocation, 1, GL_FALSE, &lightSpaceMatrix[0][0]);
 }
 
 void SkinRenderProgram::ShadowRender(Geometry::Geometry3D* geometry, const glm::mat4& viewMatrix, const glm::mat4& projectionMatrix, const glm::mat4& modelMatrix, const std::vector<glm::mat4>& bones) const {
@@ -69,9 +95,9 @@ void SkinRenderProgram::ShadowRender(Geometry::Geometry3D* geometry, const glm::
     if (frustum.Collide(geometry->GetAxisAlignedBoundingBox())) {
         glBindVertexArray(geometry->GetVertexArray());
 
-        glUniformMatrix4fv(shadowProgram->GetUniformLocation("model"), 1, GL_FALSE, &modelMatrix[0][0]);
+        glUniformMatrix4fv(shadowModelLocation, 1, GL_FALSE, &modelMatrix[0][0]);
         assert(bones.size() <= 50);
-        glUniformMatrix4fv(shadowProgram->GetUniformLocation("bones"), bones.size(), GL_FALSE, &bones[0][0][0]);
+        glUniformMatrix4fv(shadowBonesLocation, bones.size(), GL_FALSE, &bones[0][0][0]);
 
         glDrawElements(GL_TRIANGLES, geometry->GetIndexCount(), GL_UNSIGNED_INT, (void*)0);
     }
@@ -85,7 +111,7 @@ void SkinRenderProgram::PreDepthRender(const glm::mat4& viewMatrix, const glm::m
     this->projectionMatrix = projectionMatrix;
     this->viewProjectionMatrix = projectionMatrix * viewMatrix;
 
-    glUniformMatrix4fv(zShaderProgram->GetUniformLocation("viewProjection"), 1, GL_FALSE, &viewProjectionMatrix[0][0]);
+    glUniformMatrix4fv(zViewProjectionLocation, 1, GL_FALSE, &viewProjectionMatrix[0][0]);
 }
 
 void SkinRenderProgram::DepthRender(Geometry::Geometry3D* geometry, const glm::mat4& viewMatrix, const glm::mat4& projectionMatrix, const glm::mat4& modelMatrix, const std::vector<glm::mat4>& bones) const {
@@ -93,9 +119,9 @@ void SkinRenderProgram::DepthRender(Geometry::Geometry3D* geometry, const glm::m
     if (frustum.Collide(geometry->GetAxisAlignedBoundingBox())) {
         glBindVertexArray(geometry->GetVertexArray());
 
-        glUniformMatrix4fv(zShaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &modelMatrix[0][0]);
+        glUniformMatrix4fv(zModelLocation, 1, GL_FALSE, &modelMatrix[0][0]);
         assert(bones.size() <= 50);
-        glUniformMatrix4fv(zShaderProgram->GetUniformLocation("bones"), bones.size(), GL_FALSE, &bones[0][0][0]);
+        glUniformMatrix4fv(zBonesLocation, bones.size(), GL_FALSE, &bones[0][0][0]);
 
         glDrawElements(GL_TRIANGLES, geometry->GetIndexCount(), GL_UNSIGNED_INT, (void*)0);
     }
@@ -107,39 +133,39 @@ void SkinRenderProgram::PreRender(const glm::mat4& viewMatrix, const glm::mat4& 
     this->projectionMatrix = projectionMatrix;
     this->viewProjectionMatrix = projectionMatrix * viewMatrix;
 
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("viewProjection"), 1, GL_FALSE, &viewProjectionMatrix[0][0]);
+    glUniformMatrix4fv(viewProjectionLocation, 1, GL_FALSE, &viewProjectionMatrix[0][0]);
 
     // Lights.
-    glUniform1i(shaderProgram->GetUniformLocation("lightCount"), lightCount);
+    glUniform1i(lightCountLocation, lightCount);
     lightBuffer->BindBase(5);
 
     // Post processing.
     {
         float gamma = 2.2f;
-        glUniform1fv(shaderProgram->GetUniformLocation("gamma"), 1, &gamma);
+        glUniform1fv(gammaLocation, 1, &gamma);
     }
 
     {
         int fogApply = false;
         float fogDensity = 0.002f;
         glm::vec3 fogColor = glm::vec3(1, 0, 0);
-        glUniform1iv(shaderProgram->GetUniformLocation("fogApply"), 1, &fogApply);
-        glUniform1fv(shaderProgram->GetUniformLocation("fogDensity"), 1, &fogDensity);
-        glUniform3fv(shaderProgram->GetUniformLocation("fogColor"), 1, &fogColor[0]);
+        glUniform1iv(fogApplyLocation, 1, &fogApply);
+        glUniform1fv(fogDensityLocation, 1, &fogDensity);
+        glUniform3fv(fogColorLocation, 1, &fogColor[0]);
     }
 
     {
         int colorFilterApply = false;
         glm::vec3 colorFilterColor = glm::vec3(0, 1, 0);
-        glUniform1iv(shaderProgram->GetUniformLocation("colorFilterApply"), 1, &colorFilterApply);
-        glUniform3fv(shaderProgram->GetUniformLocation("colorFilterColor"), 1, &colorFilterColor[0]);
+        glUniform1iv(colorFilterApplyLocation, 1, &colorFilterApply);
+        glUniform3fv(colorFilterColorLocation, 1, &colorFilterColor[0]);
     }
 
     {
         int ditherApply = true;
         float time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count() / 1000000000.0;
-        glUniform1iv(shaderProgram->GetUniformLocation("ditherApply"), 1, &ditherApply);
-        glUniform1fv(shaderProgram->GetUniformLocation("time"), 1, &time);
+        glUniform1iv(ditherApplyLocation, 1, &ditherApply);
+        glUniform1fv(timeLocation, 1, &time);
     }
 }
 
@@ -152,11 +178,11 @@ void SkinRenderProgram::Render(const Geometry::Geometry3D* geometry, const Textu
         glBindVertexArray(geometry->GetVertexArray());
         
         // Set texture locations.
-        glUniform1i(shaderProgram->GetUniformLocation("isSelected"), false);
-        glUniform1i(shaderProgram->GetUniformLocation("mapAlbedo"), 0);
-        glUniform1i(shaderProgram->GetUniformLocation("mapNormal"), 1);
-        glUniform1i(shaderProgram->GetUniformLocation("mapMetallic"), 2);
-        glUniform1i(shaderProgram->GetUniformLocation("mapRoughness"), 3);
+        glUniform1i(isSelectedLocation, false);
+        glUniform1i(mapAlbedoLocation, 0);
+        glUniform1i(mapNormalLocation, 1);
+        glUniform1i(mapMetallicLocation, 2);
+        glUniform1i(mapRoughnessLocation, 3);
         
         // Textures.
         glActiveTexture(GL_TEXTURE0);
@@ -169,16 +195,16 @@ void SkinRenderProgram::Render(const Geometry::Geometry3D* geometry, const Textu
         glBindTexture(GL_TEXTURE_2D, textureRoughness->GetTextureID());
         
         // Render model.
-        glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &modelMatrix[0][0]);
+        glUniformMatrix4fv(modelLocation, 1, GL_FALSE, &modelMatrix[0][0]);
         glm::mat4 normalMatrix = glm::transpose(glm::inverse(viewMatrix * modelMatrix));
-        glUniformMatrix3fv(shaderProgram->GetUniformLocation("normalMatrix"), 1, GL_FALSE, &glm::mat3(normalMatrix)[0][0]);
+        glUniformMatrix3fv(normalLocation, 1, GL_FALSE, &glm::mat3(normalMatrix)[0][0]);
         assert(bones.size() <= 50);
-        glUniformMatrix4fv(shaderProgram->GetUniformLocation("bones"), bones.size(), GL_FALSE, &bones[0][0][0]);
+        glUniformMatrix4fv(bonesLocation, bones.size(), GL_FALSE, &bones[0][0][0]);
         
         glDrawElements(GL_TRIANGLES, geometry->GetIndexCount(), GL_UNSIGNED_INT, (void*)0);
 
         if (isSelected) {
-            glUniform1i(shaderProgram->GetUniformLocation("isSelected"), true);
+            glUniform1i(isSelectedLocation, true);
             glLineWidth(2.0f);
             for (int i = 0; i < geometry->GetIndexCount(); i += 3)
                 glDrawArrays(GL_LINE_LOOP, i, 3);

--- a/src/Video/RenderProgram/SkinRenderProgram.hpp
+++ b/src/Video/RenderProgram/SkinRenderProgram.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <GL/glew.h>
 #include <glm/glm.hpp>
 #include <vector>
 #include "RenderProgram.hpp"
@@ -86,6 +87,32 @@ namespace Video {
             ShaderProgram* shadowProgram;
             ShaderProgram* zShaderProgram;
             ShaderProgram* shaderProgram;
+            
+            // Uniform locations.
+            GLuint shadowLightSpaceLocation;
+            GLuint shadowModelLocation;
+            GLuint shadowBonesLocation;
+            GLuint zViewProjectionLocation;
+            GLuint zModelLocation;
+            GLuint zBonesLocation;
+            GLuint viewProjectionLocation;
+            GLuint lightCountLocation;
+            GLuint gammaLocation;
+            GLuint fogApplyLocation;
+            GLuint fogDensityLocation;
+            GLuint fogColorLocation;
+            GLuint colorFilterApplyLocation;
+            GLuint colorFilterColorLocation;
+            GLuint ditherApplyLocation;
+            GLuint timeLocation;
+            GLuint isSelectedLocation;
+            GLuint mapAlbedoLocation;
+            GLuint mapNormalLocation;
+            GLuint mapMetallicLocation;
+            GLuint mapRoughnessLocation;
+            GLuint modelLocation;
+            GLuint normalLocation;
+            GLuint bonesLocation;
 
             bool first = true;
 

--- a/src/Video/RenderProgram/StaticRenderProgram.cpp
+++ b/src/Video/RenderProgram/StaticRenderProgram.cpp
@@ -38,6 +38,34 @@ StaticRenderProgram::StaticRenderProgram() {
     shadowProgram = new ShaderProgram({ vertexShader, fragmentShader });
     delete vertexShader;
     delete fragmentShader;
+    
+    // Get uniform locations.
+    shadowLightSpaceLocation = shadowProgram->GetUniformLocation("lightSpaceMatrix");
+    shadowModelLocation = shadowProgram->GetUniformLocation("model");
+    zViewProjectionLocation = zShaderProgram->GetUniformLocation("viewProjection");
+    zModelLocation = zShaderProgram->GetUniformLocation("model");
+    viewProjectionLocation = shaderProgram->GetUniformLocation("viewProjection");
+    inverseProjectionLocation = shaderProgram->GetUniformLocation("inverseProjectionMatrix");
+    lightSpaceLocation = shaderProgram->GetUniformLocation("lightSpaceMatrix");
+    lightCountLocation = shaderProgram->GetUniformLocation("lightCount");
+    gammaLocation = shaderProgram->GetUniformLocation("gamma");
+    fogApplyLocation = shaderProgram->GetUniformLocation("fogApply");
+    fogDensityLocation = shaderProgram->GetUniformLocation("fogDensity");
+    fogColorLocation = shaderProgram->GetUniformLocation("fogColor");
+    colorFilterApplyLocation = shaderProgram->GetUniformLocation("colorFilterApply");
+    colorFilterColorLocation = shaderProgram->GetUniformLocation("colorFilterColor");
+    ditherLocation = shaderProgram->GetUniformLocation("ditherApply");
+    timeLocation = shaderProgram->GetUniformLocation("time");
+    frameSizeLocation = shaderProgram->GetUniformLocation("frameSize");
+    isSelectedLocation = shaderProgram->GetUniformLocation("isSelected");
+    mapAlbedoLocation = shaderProgram->GetUniformLocation("mapAlbedo");
+    mapNormalLocation = shaderProgram->GetUniformLocation("mapNormal");
+    mapMetallicLocation = shaderProgram->GetUniformLocation("mapMetallic");
+    mapRoughnessLocation = shaderProgram->GetUniformLocation("mapRoughness");
+    mapShadowLocation = shaderProgram->GetUniformLocation("mapShadow");
+    modelLocation = shaderProgram->GetUniformLocation("model");
+    viewLocation = shaderProgram->GetUniformLocation("viewMatrix");
+    normalLocation = shaderProgram->GetUniformLocation("normalMatrix");
 }
 
 StaticRenderProgram::~StaticRenderProgram() {
@@ -60,7 +88,7 @@ void StaticRenderProgram::PreShadowRender(const glm::mat4& viewMatrix, const glm
     this->viewProjectionMatrix = projectionMatrix * viewMatrix;
     this->shadowId = shadowId;
 
-    glUniformMatrix4fv(shadowProgram->GetUniformLocation("lightSpaceMatrix"), 1, GL_FALSE, &lightSpaceMatrix[0][0]);
+    glUniformMatrix4fv(shadowLightSpaceLocation, 1, GL_FALSE, &lightSpaceMatrix[0][0]);
 }
 
 void StaticRenderProgram::ShadowRender(Geometry::Geometry3D* geometry, const glm::mat4& viewMatrix, const glm::mat4& projectionMatrix, const glm::mat4& modelMatrix) const {
@@ -68,7 +96,7 @@ void StaticRenderProgram::ShadowRender(Geometry::Geometry3D* geometry, const glm
     if (frustum.Collide(geometry->GetAxisAlignedBoundingBox())) {
         glBindVertexArray(geometry->GetVertexArray());
 
-        glUniformMatrix4fv(shadowProgram->GetUniformLocation("model"), 1, GL_FALSE, &modelMatrix[0][0]);
+        glUniformMatrix4fv(shadowModelLocation, 1, GL_FALSE, &modelMatrix[0][0]);
 
         glDrawElements(GL_TRIANGLES, geometry->GetIndexCount(), GL_UNSIGNED_INT, (void*)0);
     }
@@ -82,7 +110,7 @@ void StaticRenderProgram::PreDepthRender(const glm::mat4& viewMatrix, const glm:
     this->projectionMatrix = projectionMatrix;
     this->viewProjectionMatrix = projectionMatrix * viewMatrix;
 
-    glUniformMatrix4fv(zShaderProgram->GetUniformLocation("viewProjection"), 1, GL_FALSE, &viewProjectionMatrix[0][0]);
+    glUniformMatrix4fv(zViewProjectionLocation, 1, GL_FALSE, &viewProjectionMatrix[0][0]);
 }
 
 void StaticRenderProgram::DepthRender(Geometry::Geometry3D* geometry, const glm::mat4& viewMatrix, const glm::mat4& projectionMatrix, const glm::mat4& modelMatrix) const {
@@ -90,7 +118,7 @@ void StaticRenderProgram::DepthRender(Geometry::Geometry3D* geometry, const glm:
     if (frustum.Collide(geometry->GetAxisAlignedBoundingBox())) {
         glBindVertexArray(geometry->GetVertexArray());
 
-        glUniformMatrix4fv(zShaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &modelMatrix[0][0]);
+        glUniformMatrix4fv(zModelLocation, 1, GL_FALSE, &modelMatrix[0][0]);
 
         glDrawElements(GL_TRIANGLES, geometry->GetIndexCount(), GL_UNSIGNED_INT, (void*)0);
     }
@@ -104,28 +132,28 @@ void StaticRenderProgram::PreRender(const glm::mat4& viewMatrix, const glm::mat4
     glm::mat4 inverseProjectionMatrix = glm::inverse(projectionMatrix);
 
     // Matrices.
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("viewProjection"), 1, GL_FALSE, &viewProjectionMatrix[0][0]);
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("inverseProjectionMatrix"), 1, GL_FALSE, &inverseProjectionMatrix[0][0]);
-    glUniformMatrix4fv(shaderProgram->GetUniformLocation("lightSpaceMatrix"), 1, GL_FALSE, &lightSpaceMatrix[0][0]);
+    glUniformMatrix4fv(viewProjectionLocation, 1, GL_FALSE, &viewProjectionMatrix[0][0]);
+    glUniformMatrix4fv(inverseProjectionLocation, 1, GL_FALSE, &inverseProjectionMatrix[0][0]);
+    glUniformMatrix4fv(lightSpaceLocation, 1, GL_FALSE, &lightSpaceMatrix[0][0]);
 
     // Lights.
-    glUniform1i(shaderProgram->GetUniformLocation("lightCount"), lightCount);
+    glUniform1i(lightCountLocation, lightCount);
     lightBuffer->BindBase(5);
 
     // Image processing.
-    glUniform1fv(shaderProgram->GetUniformLocation("gamma"), 1, &gamma);
+    glUniform1fv(gammaLocation, 1, &gamma);
 
-    glUniform1iv(shaderProgram->GetUniformLocation("fogApply"), 1, &fogApply);
-    glUniform1fv(shaderProgram->GetUniformLocation("fogDensity"), 1, &fogDensity);
-    glUniform3fv(shaderProgram->GetUniformLocation("fogColor"), 1, &fogColor[0]);
+    glUniform1iv(fogApplyLocation, 1, &fogApply);
+    glUniform1fv(fogDensityLocation, 1, &fogDensity);
+    glUniform3fv(fogColorLocation, 1, &fogColor[0]);
 
-    glUniform1iv(shaderProgram->GetUniformLocation("colorFilterApply"), 1, &colorFilterApply);
-    glUniform3fv(shaderProgram->GetUniformLocation("colorFilterColor"), 1, &colorFilterColor[0]);
+    glUniform1iv(colorFilterApplyLocation, 1, &colorFilterApply);
+    glUniform3fv(colorFilterColorLocation, 1, &colorFilterColor[0]);
 
     float time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count() % 30000000000 / 1000000000.0;
-    glUniform1iv(shaderProgram->GetUniformLocation("ditherApply"), 1, &ditherApply);
-    glUniform1fv(shaderProgram->GetUniformLocation("time"), 1, &time);
-    glUniform2fv(shaderProgram->GetUniformLocation("frameSize"), 1, &frameSize[0]);
+    glUniform1iv(ditherLocation, 1, &ditherApply);
+    glUniform1fv(timeLocation, 1, &time);
+    glUniform2fv(frameSizeLocation, 1, &frameSize[0]);
 }
 
 void StaticRenderProgram::Render(Geometry::Geometry3D* geometry, const Video::Texture2D* textureAlbedo, const Video::Texture2D* normalTexture, const Video::Texture2D* textureMetallic, const Video::Texture2D* textureRoughness, const glm::mat4& modelMatrix, bool isSelected) const {
@@ -137,12 +165,12 @@ void StaticRenderProgram::Render(Geometry::Geometry3D* geometry, const Video::Te
         glBindVertexArray(geometry->GetVertexArray());
 
         // Set texture locations
-        glUniform1i(shaderProgram->GetUniformLocation("isSelected"), false);
-        glUniform1i(shaderProgram->GetUniformLocation("mapAlbedo"), 0);
-        glUniform1i(shaderProgram->GetUniformLocation("mapNormal"), 1);
-        glUniform1i(shaderProgram->GetUniformLocation("mapMetallic"), 2);
-        glUniform1i(shaderProgram->GetUniformLocation("mapRoughness"), 3);
-        glUniform1i(shaderProgram->GetUniformLocation("mapShadow"), 4);
+        glUniform1i(isSelectedLocation, false);
+        glUniform1i(mapAlbedoLocation, 0);
+        glUniform1i(mapNormalLocation, 1);
+        glUniform1i(mapMetallicLocation, 2);
+        glUniform1i(mapRoughnessLocation, 3);
+        glUniform1i(mapShadowLocation, 4);
 
         // Textures
         glActiveTexture(GL_TEXTURE0);
@@ -157,17 +185,17 @@ void StaticRenderProgram::Render(Geometry::Geometry3D* geometry, const Video::Te
         glBindTexture(GL_TEXTURE_2D, shadowId);
 
         // Render model.
-        glUniformMatrix4fv(shaderProgram->GetUniformLocation("model"), 1, GL_FALSE, &modelMatrix[0][0]);
-        glUniformMatrix4fv(shaderProgram->GetUniformLocation("viewMatrix"), 1, GL_FALSE, &viewMatrix[0][0]);
+        glUniformMatrix4fv(modelLocation, 1, GL_FALSE, &modelMatrix[0][0]);
+        glUniformMatrix4fv(viewLocation, 1, GL_FALSE, &viewMatrix[0][0]);
         glm::mat4 normalMatrix = glm::transpose(glm::inverse(viewMatrix * modelMatrix));
-        glUniformMatrix3fv(shaderProgram->GetUniformLocation("normalMatrix"), 1, GL_FALSE, &glm::mat3(normalMatrix)[0][0]);
+        glUniformMatrix3fv(normalLocation, 1, GL_FALSE, &glm::mat3(normalMatrix)[0][0]);
 
-        glUniform1i(shaderProgram->GetUniformLocation("isSelected"), false);
+        glUniform1i(isSelectedLocation, false);
 
         glDrawElements(GL_TRIANGLES, geometry->GetIndexCount(), GL_UNSIGNED_INT, (void*)0);
 
         if (isSelected) {
-            glUniform1i(shaderProgram->GetUniformLocation("isSelected"), true);
+            glUniform1i(isSelectedLocation, true);
             glLineWidth(2.0f);
             for (int i = 0; i < geometry->GetIndexCount(); i += 3)
                 glDrawArrays(GL_LINE_LOOP, i, 3);

--- a/src/Video/RenderProgram/StaticRenderProgram.hpp
+++ b/src/Video/RenderProgram/StaticRenderProgram.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <GL/glew.h>
 #include <glm/glm.hpp>
 #include "RenderProgram.hpp"
 
@@ -82,6 +83,34 @@ namespace Video {
             ShaderProgram* shadowProgram;
             ShaderProgram* zShaderProgram;
             ShaderProgram* shaderProgram;
+            
+            // Uniform locations.
+            GLuint shadowLightSpaceLocation;
+            GLuint shadowModelLocation;
+            GLuint zViewProjectionLocation;
+            GLuint zModelLocation;
+            GLuint viewProjectionLocation;
+            GLuint inverseProjectionLocation;
+            GLuint lightSpaceLocation;
+            GLuint lightCountLocation;
+            GLuint gammaLocation;
+            GLuint fogApplyLocation;
+            GLuint fogDensityLocation;
+            GLuint fogColorLocation;
+            GLuint colorFilterApplyLocation;
+            GLuint colorFilterColorLocation;
+            GLuint ditherLocation;
+            GLuint timeLocation;
+            GLuint frameSizeLocation;
+            GLuint isSelectedLocation;
+            GLuint mapAlbedoLocation;
+            GLuint mapNormalLocation;
+            GLuint mapMetallicLocation;
+            GLuint mapRoughnessLocation;
+            GLuint mapShadowLocation;
+            GLuint modelLocation;
+            GLuint viewLocation;
+            GLuint normalLocation;
 
             bool first = true;
       

--- a/src/Video/Renderer.cpp
+++ b/src/Video/Renderer.cpp
@@ -43,6 +43,13 @@ Renderer::Renderer() {
     delete iconVertexShader;
     delete iconGeometryShader;
     delete iconFragmentShader;
+    
+    // Get uniform locations.
+    viewProjectionLocation = iconShaderProgram->GetUniformLocation("viewProjectionMatrix");
+    cameraPositionLocation = iconShaderProgram->GetUniformLocation("cameraPosition");
+    cameraUpLocation = iconShaderProgram->GetUniformLocation("cameraUp");
+    baseImageLocation = iconShaderProgram->GetUniformLocation("baseImage");
+    positionLocation = iconShaderProgram->GetUniformLocation("position");
 
     // Create icon geometry.
     float vertex;
@@ -175,10 +182,10 @@ void Renderer::PrepareRenderingIcons(const glm::mat4& viewProjectionMatrix, cons
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
     // Set camera uniforms.
-    glUniformMatrix4fv(iconShaderProgram->GetUniformLocation("viewProjectionMatrix"), 1, GL_FALSE, &viewProjectionMatrix[0][0]);
-    glUniform3fv(iconShaderProgram->GetUniformLocation("cameraPosition"), 1, &cameraPosition[0]);
-    glUniform3fv(iconShaderProgram->GetUniformLocation("cameraUp"), 1, &cameraUp[0]);
-    glUniform1i(iconShaderProgram->GetUniformLocation("baseImage"), 0);
+    glUniformMatrix4fv(viewProjectionLocation, 1, GL_FALSE, &viewProjectionMatrix[0][0]);
+    glUniform3fv(cameraPositionLocation, 1, &cameraPosition[0]);
+    glUniform3fv(cameraUpLocation, 1, &cameraUp[0]);
+    glUniform1i(baseImageLocation, 0);
     glActiveTexture(GL_TEXTURE0);
 }
 
@@ -188,7 +195,7 @@ void Renderer::RenderIcon(const glm::vec3& position, const Texture2D* icon) {
         glBindTexture(GL_TEXTURE_2D, icon->GetTextureID());
     }
 
-    glUniform3fv(iconShaderProgram->GetUniformLocation("position"), 1, &position[0]);
+    glUniform3fv(positionLocation, 1, &position[0]);
     glDrawArrays(GL_POINTS, 0, 1);
 }
 

--- a/src/Video/Renderer.hpp
+++ b/src/Video/Renderer.hpp
@@ -334,6 +334,13 @@ namespace Video {
             GLuint vertexBuffer;
             GLuint vertexArray;
             const Texture2D* currentIcon = nullptr;
+            
+            // Uniform locations.
+            GLuint viewProjectionLocation;
+            GLuint cameraPositionLocation;
+            GLuint cameraUpLocation;
+            GLuint baseImageLocation;
+            GLuint positionLocation;
 
             Geometry::Rectangle* rectangle;
     };


### PR DESCRIPTION
Store uniform locations in variables and use those rather than re-fetching them each frame.

Fixes #848 