### PR TITLE
Triggers: Swapped dropdown menu for input on CollidedEntity.

### DIFF
--- a/src/Editor/GUI/Editors/TriggerEditor.cpp
+++ b/src/Editor/GUI/Editors/TriggerEditor.cpp
@@ -193,22 +193,17 @@ namespace GUI {
 
                         // Subject
                         ImGui::NextColumn();
-                        int shapeID = repeat->GetEventVector()->at(i).m_shapeID;
-                        std::vector<std::string> entityWithShape;
-                        for (std::size_t i = 0; i < Hymn().world.GetEntities().size(); ++i) {
-                            if (Hymn().world.GetEntities().at(i)->GetComponent<Component::RigidBody>() != nullptr)
-                                entityWithShape.push_back(Hymn().world.GetEntities().at(i)->name);
-                        }
+                        int collidedEntityUID = repeat->GetCollidedEntityUID();
+                        if (ImGui::InputInt("Input UID: ", &collidedEntityUID)) {
 
-                        if (ImGui::Combo(labelShape.c_str(), &shapeID, entityWithShape)) {
-                            repeat->GetEventVector()->at(i).m_shapeID = shapeID;
-
-                            for (std::size_t j = 0; j < Hymn().world.GetEntities().size(); ++j) {
-                                if (Hymn().world.GetEntities().at(j)->name == entityWithShape.at(shapeID)) {
-                                    repeat->GetCollidedEntity()->push_back(Hymn().world.GetEntities().at(j));
-                                    repeat->GetEventVector()->at(i).check[1] = true;
+                            for (std::size_t i = 0; i < Hymn().world.GetEntities().size(); ++i) {
+                                if (Hymn().world.GetEntities().at(i)->GetUniqueIdentifier() == collidedEntityUID && Hymn().world.GetEntities().at(i)->GetComponent<Component::RigidBody>()) {
+                                    repeat->GetCollidedEntity()->push_back(Hymn().world.GetEntities().at(i));
                                 }
+                                    
                             }
+                            repeat->SetCollidedEntityUID(collidedEntityUID);
+                            repeat->GetEventVector()->at(i).check[1] = true;
                         }
 
                         // Entity target

--- a/src/Engine/Manager/TriggerManager.cpp
+++ b/src/Engine/Manager/TriggerManager.cpp
@@ -69,6 +69,7 @@ Component::Trigger* TriggerManager::CreateTrigger(const Json::Value& node) {
 
         repeat->eventVector.push_back(eventstruct);
 
+        repeat->collidedEntityUID = node.get("triggerCollidedEntityUID", 0).asInt();
         repeat->triggered = node.get("triggerTriggered", false).asBool();
 
         repeat->triggerVolume = triggerVolume;

--- a/src/Engine/Trigger/TriggerRepeat.cpp
+++ b/src/Engine/Trigger/TriggerRepeat.cpp
@@ -206,6 +206,7 @@ Json::Value TriggerRepeat::Save() {
                 
     }
 
+    component["triggerCollidedEntityUID"] = collidedEntityUID;
     component["triggerTriggered"] = triggered;
 
     if (owningEntity != nullptr)
@@ -213,4 +214,12 @@ Json::Value TriggerRepeat::Save() {
 
     return component;
 
+}
+
+void TriggerRepeat::SetCollidedEntityUID(int value) {
+    collidedEntityUID = value;
+}
+
+int TriggerRepeat::GetCollidedEntityUID() {
+    return collidedEntityUID;
 }

--- a/src/Engine/Trigger/TriggerRepeat.hpp
+++ b/src/Engine/Trigger/TriggerRepeat.hpp
@@ -162,6 +162,18 @@ class TriggerRepeat : public SuperTrigger {
         /// Initialize trigger volumes.
         ENGINE_API void InitiateVolumes() override;
 
+        /// Set UID for this triggers collided entity.
+        /**
+         * @param value Set UID for collided entity.
+         */
+        ENGINE_API void SetCollidedEntityUID(int value);
+
+        /// Get UID for this triggers collided entity.
+        /**
+         * @return int unique identifier for collided entity.
+         */
+        ENGINE_API int GetCollidedEntityUID();
+
     private:
         void HandleTriggerEvent();
 


### PR DESCRIPTION
Triggers: Users now have to input GUID of the entity they want to check collision for instead of having a dropdown list.