### PR TITLE
Disable fog when disabling lighting

### DIFF
--- a/src/Engine/Manager/RenderManager.cpp
+++ b/src/Engine/Manager/RenderManager.cpp
@@ -97,7 +97,7 @@ void RenderManager::Render(World& world, bool soundSources, bool particleEmitter
     if (camera != nullptr) {
         // Set image processing variables.
         renderer->SetGamma(Hymn().filterSettings.gamma);
-        renderer->SetFogApply(Hymn().filterSettings.fogApply);
+        renderer->SetFogApply(Hymn().filterSettings.fogApply && lighting);
         renderer->SetFogDensity(Hymn().filterSettings.fogDensity);
         renderer->SetFogColor(Hymn().filterSettings.fogColor);
         renderer->SetColorFilterApply(Hymn().filterSettings.colorFilterApply);


### PR DESCRIPTION
Makes things easier to see in the editor without having to disable the fog (which disables it not just for the editor but also in-game). The reason for doing this as part of the lighting option rather than its own option is because it wasn't deemed desirable to disable fog without disabling the lighting.

Fixes #925 