### PR TITLE
Voltage logic fix

### DIFF
--- a/Game/Resources/VoltageScene/Scripts/Mastermind.as
+++ b/Game/Resources/VoltageScene/Scripts/Mastermind.as
@@ -49,6 +49,8 @@ class Mastermind {
         if (puzzleSolved)
             return;
 
+        TurnOffLights();
+        
         for (int i = 0; i < correct; i++)
             TurnOnLight(100, vec3(0, 255, 0));
 

--- a/Game/Resources/VoltageScene/Scripts/Mastermind.as
+++ b/Game/Resources/VoltageScene/Scripts/Mastermind.as
@@ -53,6 +53,9 @@ class Mastermind {
 
         for (int i = 0; i < rightColors; i++)
             TurnOnLight(20, vec3(232, 215, 27));
+            
+        for (int i = 0; i < 4 - (correct + rightColors); ++i)
+            TurnOnLight(20, vec3(255, 0, 0));
     }
 
     void CheckSolution() {

--- a/Game/Resources/VoltageScene/Scripts/Mastermind.as
+++ b/Game/Resources/VoltageScene/Scripts/Mastermind.as
@@ -46,9 +46,6 @@ class Mastermind {
 
     // Called by the engine for each frame.
     void Update(float deltaTime) {
-        if (puzzleSolved)
-            return;
-
         TurnOffLights();
         
         for (int i = 0; i < correct; i++)

--- a/Game/Resources/VoltageScene/Scripts/Mastermind.as
+++ b/Game/Resources/VoltageScene/Scripts/Mastermind.as
@@ -49,10 +49,10 @@ class Mastermind {
         TurnOffLights();
         
         for (int i = 0; i < correct; i++)
-            TurnOnLight(100, vec3(0, 255, 0));
+            TurnOnLight(20, vec3(0, 255, 0));
 
         for (int i = 0; i < rightColors; i++)
-            TurnOnLight(100, vec3(255, 0, 0));
+            TurnOnLight(20, vec3(232, 215, 27));
     }
 
     void CheckSolution() {

--- a/Game/Resources/VoltageScene/Scripts/Propp.as
+++ b/Game/Resources/VoltageScene/Scripts/Propp.as
@@ -74,6 +74,7 @@ class Propp {
     void ReturnToStartPosition() {
         self.SetParent(originalParent);
         self.position = startPosition;
+        slot = -1;
     }
 
     void PickupTrigger() {

--- a/Game/Resources/VoltageScene/VoltageScene.json
+++ b/Game/Resources/VoltageScene/VoltageScene.json
@@ -2780,7 +2780,7 @@
 					"SpotLight" : 
 					{
 						"ambientCoefficient" : 0.0,
-						"attenuation" : 200.0,
+						"attenuation" : 20000.0,
 						"color" : 
 						{
 							"x" : 1.0,
@@ -2820,7 +2820,7 @@
 					"SpotLight" : 
 					{
 						"ambientCoefficient" : 0.0,
-						"attenuation" : 200.0,
+						"attenuation" : 20000.0,
 						"color" : 
 						{
 							"x" : 1.0,
@@ -2860,7 +2860,7 @@
 					"SpotLight" : 
 					{
 						"ambientCoefficient" : 0.0,
-						"attenuation" : 200.0,
+						"attenuation" : 20000.0,
 						"color" : 
 						{
 							"x" : 1.0,
@@ -2900,7 +2900,7 @@
 					"SpotLight" : 
 					{
 						"ambientCoefficient" : 0.0,
-						"attenuation" : 200.0,
+						"attenuation" : 20000.0,
 						"color" : 
 						{
 							"x" : 1.0,
@@ -4103,7 +4103,7 @@
 			"SpotLight" : 
 			{
 				"ambientCoefficient" : 0.0,
-				"attenuation" : 6.1880002021789551,
+				"attenuation" : 300.0,
 				"color" : 
 				{
 					"x" : 1.0,
@@ -4111,7 +4111,7 @@
 					"z" : 1.0
 				},
 				"coneAngle" : 34.047000885009766,
-				"intensity" : 18.590000152587891,
+				"intensity" : 60.0,
 				"shadow" : false
 			},
 			"children" : null,

--- a/Game/Resources/VoltageScene/VoltageScene.json
+++ b/Game/Resources/VoltageScene/VoltageScene.json
@@ -905,7 +905,7 @@
 										"triggerEventStruct_Check_1" : true,
 										"triggerEventStruct_Check_2" : true,
 										"triggerEventStruct_Check_3" : true,
-										"triggerEventStruct_EventID" : 0,
+										"triggerEventStruct_EventID" : 1,
 										"triggerEventStruct_ScriptID" : 2,
 										"triggerEventStruct_ShapeID" : 0,
 										"triggerEventStruct_TargetID" : 11,


### PR DESCRIPTION
This PR includes the following changes:
- The pink fuse can now be inserted into the first slot
- Solution lights are now correct when the attempt includes fuses that are not part of the solution
- Solution lights are now lit when the game is completed
- Replacing a fuse and attempting to pick up the automatically returned one no longer causes the fuse in the original slot to be evicted
- Right color but wrong slot is now represented by a yellow light
- Red lights are shown for completely wrong fuses
- General lighting tweaks to reduce leakage